### PR TITLE
INFRA-488 Add IIIF documentation

### DIFF
--- a/docs/iiif/index.md
+++ b/docs/iiif/index.md
@@ -20,32 +20,32 @@ last_modified_date: 2022-03-14T11:40:08+0100
 Het [Image Interoperability Framework](https://iiif.io) (IIIF) is een set van open standaarden om gedigitaliseerde archieven online beschikbaar te stellen. Het zorgt voor een gebruiksvriendelijke toegang tot de objecten uit een archief.  
 Het IIIF-protocol maakt gebruik van een stabiel manifest, en voorziet een duurzame URL voor elk object in het archief. Hierdoor kunnen er later eventueel andere versies van eenzelfde object worden toegevoegd aan een collectie (bijvoorbeeld in een hogere resolutie) zonder dat de URL van dit object wijzigt. 
 
-Het IIIF-protocal bestaat uit 6 API's, die onafhankelijk van elkaar kunnen worden gebruikt. Momenteel wordt er enkel gebruik gemaakt van de Image API, wat de gebruiker in staat stelt om op een performante manier (delen van) afbeeldingen te bekijken, te herschalen, te roteren,... 
+Het IIIF-protocol bestaat uit 6 API's, die onafhankelijk van elkaar gebruikt kunnen worden. Momenteel wordt enkel de Image API benut. Dit stelt de gebruiker in staat om op een performante manier (delen van) afbeeldingen te bekijken, te herschalen, te roteren,... 
 
 ## Authenticatie
 
-De door meemoo voorziene IIIF-endpoints zijn publiek beschikbaar; er is dus geen authenticatie vereist. 
+De door meemoo voorziene IIIF-endpoints zijn publiek beschikbaar, er is dus geen authenticatie vereist. 
 
 ## Endpoint
 
-Er wordt gebruik gemaakt van de de Image API versie 3.0. 
-Het meemoo Image API endpoint voldoet aan het hoogste IIIF-compliance level, nl. 2. 
-Meer info over IIIF en de Image API kan teruggevonden worden op de [iiif.io website](https://iiif.io/api/image/3.0/). 
+Er wordt gebruik gemaakt van de Image API versie 3.0. 
+Het meemoo-Image-API-endpoint voldoet aan het hoogste IIIF-compliance level, namelijk level 2. 
+Meer info over IIIF en de Image API kan je terugvinden op de [iiif.io website](https://iiif.io/api/image/3.0/). 
 
 ### Omgevingen
 
-Het endpoint is beschikbaar op 3 omgevingen (TST, QAS, PRD).  
-(!) Let op dat de afbeeldingen kunnen verschillen van omgeving tot omgeving, afhankelijk van de beschikbaarheid in het meemoo-archief. 
+Het endpoint is beschikbaar op 3 omgevingen: TST, QAS en PRD.  
+Let op: de afbeeldingen kunnen verschillen van omgeving tot omgeving, afhankelijk van de beschikbaarheid in het meemoo-archiefsysteem. 
 
 ### Opbouw URL
 
-Om een afbeelding via op te halen via een URL, wordt deze URL als volgt opgebouwd: 
+Om een afbeelding op te halen via een URL, wordt de URL als volgt opgebouwd: 
 
 ```shell
 https://{DOMEIN}/iiif/{IDENTIFIER}.jp2/{REGIO}/{GROOTTE}/{ROTATIE}/{KWALITEIT}.{FORMAAT}
 ```
 
-Hieronder volgt een beknopte samenvatting van de mogelijkheden van het endpoint waarbij elke parameter afzonderlijk wordt toegelicht.  
+Hieronder volgt een beknopte samenvatting van de mogelijkheden van het endpoint, waarbij elke parameter afzonderlijk wordt toegelicht.  
 Voor een uitgebreide beschrijving van de URL-samenstelling, zie de [iiif.io documentatie](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax).
 
 #### Domein
@@ -61,36 +61,36 @@ Het domein geeft aan vanuit welke omgeving het object wordt opgevraagd. Er zijn 
 
 #### Identifier
 
-De identifier van het op te halen object moet overeenkomen met de `OriginalFilename` van het object, welke terug te vinden is in de metadata van het gewenste object.  
+De identifier van het op te halen object moet overeenkomen met de `OriginalFilename` van het object. Dit vind je terug in de metadata van het gewenste object.  
 Een lijst van beschikbare identifiers is te raadplegen via de [inventaris](https://images.meemoo.be/inventory).
 
 #### Regio
 
-De parameter `REGIO` bepaalt welk rechthoekig vlak uit de afbeelding teruggegeven wordt. Een regio kan uitgedrukt worden in pixel-coördinaten, percentages of door de waarde `full`. Deze laatste optie zorgt ervoor dat de volledige afbeelding teruggegeven wordt. 
+De parameter `REGIO` bepaalt welk rechthoekig vlak uit de afbeelding teruggegeven wordt. Een regio kan uitgedrukt worden in pixelcoördinaten, percentages of door de waarde `full`. Deze laatste optie zorgt ervoor dat de volledige afbeelding teruggegeven wordt. 
 
 #### Grootte
 
-De parameter `GROOTTE` geeft aan tot welke grootte de gekozen regio geschaald moet worden. `max` kan hier ingevuld worden om de afbeeldingen maximaal te laten schalen (opschaling is hier niet van toepassing). 
+De parameter `GROOTTE` geeft aan tot welke grootte de gekozen regio geschaald moet worden. Je kan hier `max` invullen om de afbeeldingen maximaal te laten schalen. Opschaling is hier niet van toepassing. 
 
-Alle afbeeldingen die beschikbaar zijn via het meemoo IIIF-endpoint hebben een maximale lengte of breedte van 5000 pixels. Afbeeldingen die auteursrechtelijk beschermd zijn, worden ontsloten in 640x480 pixel formaat. 
+Alle afbeeldingen die beschikbaar zijn via het meemoo-IIIF-endpoint hebben een maximale lengte of breedte van 5000 pixels. Afbeeldingen die auteursrechtelijk beschermd zijn, worden ontsloten in 640x480 pixelformaat. 
 
 #### Rotatie
 
-De afbeelding kan ook geroteerd worden getoond, hiervoor kan een getal tussen 0 en 360 worden meegegeven in de URL. Dit getal geeft het aantal graden draaiing met de klok mee aan. 
+De afbeelding kan ook geroteerd worden getoond, hiervoor kan je een getal tussen 0 en 360 meegeven in de URL. Dit getal geeft het aantal graden draaiing met de klok mee aan. 
 
 #### Kwaliteit
 
-Om de kwaliteit van de afbeelding te bepalen, kan er gekozen worden uit volgende waardes: 
+Om de kwaliteit van de afbeelding te bepalen, kan je kiezen uit de volgende waardes: 
 - `color`
 - `gray`
 - `bitonal`
 - `default` 
 
-Deze waarde zal bepalen of de afbeelding wordt getoond in respectievelijk kleur, grijswaarden, of zwart/wit. 
+Deze waarde zal bepalen of de afbeelding getoond wordt in kleur, grijswaarden of zwart-wit. 
 
 #### Formaat
 
-Als formaat kan er gekozen worden tussen `jpg` en `png`, afhankelijk van het gewenste afbeeldingformaat. 
+Als formaat kan je kiezen tussen `jpg` en `png`, afhankelijk van het gewenste afbeeldingsformaat. 
 
 ### Inventaris
 
@@ -102,13 +102,13 @@ Een inventaris van de beschikbare beelden is terug te vinden op [https://images.
 
 Deze paragraaf beschrijft een use case waarbij een object wordt opgehaald via het IIIF-endpoint en getoond wordt in de browser. 
 Volgende transformaties worden toegepast op het object: 
-- Een bepaalde regio selecteren
-- Schaling van de gekozen regio
-- Rotatie van de gekozen regio
-- De gekozen regio in grijswaarden tonen
-- Formaatkeuze van de afbeelding
+- een bepaalde regio selecteren
+- schaling van de gekozen regio
+- rotatie van de gekozen regio
+- de gekozen regio in grijswaarden tonen
+- formaatkeuze van de afbeelding
 
-In deze use case wordt slechts een subset van de mogelijkheden van een IIIF-endpoint gebruikt. Voor de volledige waaier aan mogelijkheden, zie de Image API [documentatie](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax). 
+In deze use case wordt slechts een subset van de mogelijkheden van een IIIF-endpoint gebruikt. Voor de volledige waaier aan mogelijkheden, zie de Image API-[documentatie](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax). 
 
 ## Stap 1: Bepalen van de identifier
 
@@ -124,7 +124,7 @@ Indien de identifier wordt ingevuld, is de URL als volgt:
 https://images.meemoo.be/iiif/h12v432j8x.jp2/full/full/0/default.jpg
 ```
 
-Wanneer naar deze URL gesurft wordt, wordt de volledige afbeelding teruggegeven, zonder enige toegepaste transformaties.  
+Wanneer je naar deze URL surft, wordt de volledige afbeelding teruggegeven, zonder enige toegepaste transformaties.  
 
 ### Regio
 
@@ -144,7 +144,7 @@ De getoonde afbeelding is bijgesneden naargelang de gekozen waardes.
 
 ### Grootte
 
-Om de gekozen regio te schalen tot een maximum breedte van 300px en een maximum hoogte van 400px zonder de aspect ratio te verliezen, kan de parameter `GROOTTE` als volgt worden ingevuld:
+Om de gekozen regio te schalen tot een maximum breedte van 300px en een maximum hoogte van 400px zonder de beeldverhouding te verliezen, kan de parameter `GROOTTE` als volgt worden ingevuld:
 
 ```shell
 https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/0/default.jpg
@@ -154,7 +154,7 @@ In dit geval wordt de eerder gekozen regio van de afbeelding teruggegeven met ee
 
 ### Rotatie
 
-Indien de geschaalde regio 90 graden met de klok mee geroteerd moet worden, kan de URL aangepast worden als volgt: 
+Indien de geschaalde regio 90 graden met de klok mee geroteerd moet worden, kan de URL als volgt worden aangepast: 
 
 ```shell
 https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/90/default.jpg
@@ -162,7 +162,7 @@ https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/90/def
 
 ### Kwaliteit
 
-Om de afbeelding in grijswaarden weer te geven, kan `gray` worden ingevuld voor de parameter `KWALITEIT`. 
+Om de afbeelding in grijswaarden weer te geven, kan je `gray` invullen bij de parameter `KWALITEIT`. 
 
 ```shell
 https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/90/gray.jpg

--- a/docs/iiif/index.md
+++ b/docs/iiif/index.md
@@ -17,10 +17,10 @@ last_modified_date: 2022-03-14T11:40:08+0100
 
 # Over IIIF 
 
-[Image Interoperability Framework](https://iiif.io) (IIIF) is een set van open standaarden om gedigitaliseerde archieven online beschikbaar te stellen. Het zorgt voor een gebruiksvriendelijke toegang tot de objecten uit een archief.  
+Het [Image Interoperability Framework](https://iiif.io) (IIIF) is een set van open standaarden om gedigitaliseerde archieven online beschikbaar te stellen. Het zorgt voor een gebruiksvriendelijke toegang tot de objecten uit een archief.  
 Het IIIF-protocol maakt gebruik van een stabiel manifest, en voorziet een duurzame URL voor elk object in het archief. Hierdoor kunnen er later eventueel andere versies van eenzelfde object worden toegevoegd aan een collectie (bijvoorbeeld in een hogere resolutie) zonder dat de URL van dit object wijzigt. 
 
-Het IIIF-protocal bestaat uit 6 API's, die onafhankelijk van elkaar kunnen worden gebruikt. Momenteel wordt er enkel gebruik gemaakt van de Image API, wat de gebruiker in staat stelt om (delen van) afbeeldingen te bekijken, herschalen, roteren,... op een performante manier. 
+Het IIIF-protocal bestaat uit 6 API's, die onafhankelijk van elkaar kunnen worden gebruikt. Momenteel wordt er enkel gebruik gemaakt van de Image API, wat de gebruiker in staat stelt om op een performante manier (delen van) afbeeldingen te bekijken, te herschalen, te roteren,... 
 
 ## Authenticatie
 
@@ -30,7 +30,7 @@ De door meemoo voorziene IIIF-endpoints zijn publiek beschikbaar; er is dus geen
 
 Er wordt gebruik gemaakt van de de Image API versie 3.0. 
 Het meemoo Image API endpoint voldoet aan het hoogste IIIF-compliance level, nl. 2. 
-Meer info over IIIF en de Image API kan teruggevonden worden op de iiif.io [website](https://iiif.io/api/image/3.0/). 
+Meer info over IIIF en de Image API kan teruggevonden worden op de [iiif.io website](https://iiif.io/api/image/3.0/). 
 
 ### Omgevingen
 
@@ -46,7 +46,7 @@ https://{DOMEIN}/iiif/{IDENTIFIER}.jp2/{REGIO}/{GROOTTE}/{ROTATIE}/{KWALITEIT}.{
 ```
 
 Hieronder volgt een beknopte samenvatting van de mogelijkheden van het endpoint waarbij elke parameter afzonderlijk wordt toegelicht.  
-Voor een uitgebreide beschrijving van de URL-samenstelling, zie de iiif.io [documentatie](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax).
+Voor een uitgebreide beschrijving van de URL-samenstelling, zie de [iiif.io documentatie](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax).
 
 #### Domein
 

--- a/docs/iiif/index.md
+++ b/docs/iiif/index.md
@@ -1,0 +1,178 @@
+---
+layout: default
+title: IIIF
+has_children: false
+nav_order: 5
+last_modified_date: 2022-03-14T11:40:08+0100
+---
+
+<details markdown="block">
+  <summary>
+    Inhoudstafel
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+# Over IIIF 
+
+[Image Interoperability Framework](https://iiif.io) (IIIF) is een set van open standaarden om gedigitaliseerde archieven online beschikbaar te stellen. Het zorgt voor een gebruiksvriendelijke toegang tot de objecten uit een archief.  
+Het IIIF-protocol maakt gebruik van een stabiel manifest, en voorziet een duurzame URL voor elk object in het archief. Hierdoor kunnen er later eventueel andere versies van eenzelfde object worden toegevoegd aan een collectie (bijvoorbeeld in een hogere resolutie) zonder dat de URL van dit object wijzigt. 
+
+Het IIIF-protocal bestaat uit 6 API's, die onafhankelijk van elkaar kunnen worden gebruikt. Momenteel wordt er enkel gebruik gemaakt van de Image API, wat de gebruiker in staat stelt om (delen van) afbeeldingen te bekijken, herschalen, roteren,... op een performante manier. 
+
+## Authenticatie
+
+De door meemoo voorziene IIIF-endpoints zijn publiek beschikbaar; er is dus geen authenticatie vereist. 
+
+## Endpoint
+
+Er wordt gebruik gemaakt van de de Image API versie 3.0. 
+Het meemoo Image API endpoint voldoet aan het hoogste IIIF-compliance level, nl. 2. 
+Meer info over IIIF en de Image API kan teruggevonden worden op de iiif.io [website](https://iiif.io/api/image/3.0/). 
+
+### Omgevingen
+
+Het endpoint is beschikbaar op 3 omgevingen (TST, QAS, PRD).  
+(!) Let op dat de afbeeldingen kunnen verschillen van omgeving tot omgeving, afhankelijk van de beschikbaarheid in het meemoo-archief. 
+
+### Opbouw URL
+
+Om een afbeelding via op te halen via een URL, wordt deze URL als volgt opgebouwd: 
+
+```shell
+https://{DOMEIN}/iiif/{IDENTIFIER}.jp2/{REGIO}/{GROOTTE}/{ROTATIE}/{KWALITEIT}.{FORMAAT}
+```
+
+Hieronder volgt een beknopte samenvatting van de mogelijkheden van het endpoint waarbij elke parameter afzonderlijk wordt toegelicht.  
+Voor een uitgebreide beschrijving van de URL-samenstelling, zie de iiif.io [documentatie](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax).
+
+#### Domein
+
+Het domein geeft aan vanuit welke omgeving het object wordt opgevraagd. Er zijn 3 omgevingen beschikbaar: TST, QAS en PRD.  
+
+| Omgeving | Domein                                               |
+|----------|------------------------------------------------------|
+| TST      | [images-tst.meemoo.be](https://images-tst.meemoo.be) |
+| QAS      | [images-qas.meemoo.be](https://images-qas.meemoo.be) |
+| PRD      | [images.meemoo.be](https://images.meemoo.be)         |
+
+
+#### Identifier
+
+De identifier van het op te halen object moet overeenkomen met de `OriginalFilename` van het object, welke terug te vinden is in de metadata van het gewenste object.  
+Een lijst van beschikbare identifiers is te raadplegen via de [inventaris](https://images.meemoo.be/inventory).
+
+#### Regio
+
+De parameter `REGIO` bepaalt welk rechthoekig vlak uit de afbeelding teruggegeven wordt. Een regio kan uitgedrukt worden in pixel-coördinaten, percentages of door de waarde `full`. Deze laatste optie zorgt ervoor dat de volledige afbeelding teruggegeven wordt. 
+
+#### Grootte
+
+De parameter `GROOTTE` geeft aan tot welke grootte de gekozen regio geschaald moet worden. `max` kan hier ingevuld worden om de afbeeldingen maximaal te laten schalen (opschaling is hier niet van toepassing). 
+
+Alle afbeeldingen die beschikbaar zijn via het meemoo IIIF-endpoint hebben een maximale lengte of breedte van 5000 pixels. Afbeeldingen die auteursrechtelijk beschermd zijn, worden ontsloten in 640x480 pixel formaat. 
+
+#### Rotatie
+
+De afbeelding kan ook geroteerd worden getoond, hiervoor kan een getal tussen 0 en 360 worden meegegeven in de URL. Dit getal geeft het aantal graden draaiing met de klok mee aan. 
+
+#### Kwaliteit
+
+Om de kwaliteit van de afbeelding te bepalen, kan er gekozen worden uit volgende waardes: 
+- `color`
+- `gray`
+- `bitonal`
+- `default` 
+
+Deze waarde zal bepalen of de afbeelding wordt getoond in respectievelijk kleur, grijswaarden, of zwart/wit. 
+
+#### Formaat
+
+Als formaat kan er gekozen worden tussen `jpg` en `png`, afhankelijk van het gewenste afbeeldingformaat. 
+
+### Inventaris
+
+Een inventaris van de beschikbare beelden is terug te vinden op [https://images.meemoo.be/inventory](https://images.meemoo.be/inventory). 
+
+# Use case 
+
+## Algemeen
+
+Deze paragraaf beschrijft een use case waarbij een object wordt opgehaald via het IIIF-endpoint en getoond wordt in de browser. 
+Volgende transformaties worden toegepast op het object: 
+- Een bepaalde regio selecteren
+- Schaling van de gekozen regio
+- Rotatie van de gekozen regio
+- De gekozen regio in grijswaarden tonen
+- Formaatkeuze van de afbeelding
+
+In deze use case wordt slechts een subset van de mogelijkheden van een IIIF-endpoint gebruikt. Voor de volledige waaier aan mogelijkheden, zie de Image API [documentatie](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax). 
+
+## Stap 1: Bepalen van de identifier
+
+Stel dat het object 'De bespotting van Christus (Ecce Homo)' van James Ensor getoond moet worden. De [inventaris](https://images.meemoo.be/inventory) geeft aan dat de originele bestandsnaam van dit werk `h12v432j8x` is (zie kolom `Descriptive.OriginalFilename`). 
+
+## Stap 2: De URL opbouwen
+
+### Identifier
+
+Indien de identifier wordt ingevuld, is de URL als volgt: 
+
+```shell 
+https://images.meemoo.be/iiif/h12v432j8x.jp2/full/full/0/default.jpg
+```
+
+Wanneer naar deze URL gesurft wordt, wordt de volledige afbeelding teruggegeven, zonder enige toegepaste transformaties.  
+
+### Regio
+
+Stel dat een regio met volgende eigenschappen gecapteerd moet worden: 
+- 1700 pixels offset links
+- 1300 pixels offset boven
+- 1100 pixels breedte
+- 1750 pixels hoogte
+
+In dit geval wordt de URL als volgt opgebouwd: 
+
+```shell
+https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/full/0/default.jpg
+```
+
+De getoonde afbeelding is bijgesneden naargelang de gekozen waardes. 
+
+### Grootte
+
+Om de gekozen regio te schalen tot een maximum breedte van 300px en een maximum hoogte van 400px zonder de aspect ratio te verliezen, kan de parameter `GROOTTE` als volgt worden ingevuld:
+
+```shell
+https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/0/default.jpg
+```
+
+In dit geval wordt de eerder gekozen regio van de afbeelding teruggegeven met een breedte van 251px en een hoogte van 400px. 
+
+### Rotatie
+
+Indien de geschaalde regio 90 graden met de klok mee geroteerd moet worden, kan de URL aangepast worden als volgt: 
+
+```shell
+https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/90/default.jpg
+```
+
+### Kwaliteit
+
+Om de afbeelding in grijswaarden weer te geven, kan `gray` worden ingevuld voor de parameter `KWALITEIT`. 
+
+```shell
+https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/90/gray.jpg
+```
+
+### Formaat
+
+Om de afbeelding in PNG-formaat te verkrijgen, wordt `jpg` in de URL simpelweg vervangen door `png`. 
+
+``` shell
+https://images.meemoo.be/iiif/h12v432j8x.jp2/1700,1300,1100,1750/!300,400/90/gray.jpg
+```
+


### PR DESCRIPTION
Add documentation for VKC regarding the IIIF-endpoint (`images.meemoo.be/iiif`). 

The [OAI-PMH file](https://github.com/viaacode/documentation/blob/master/docs/oai-pmh/index.md) was used as an example.  