### PR TITLE
META-136 Have consistent values for xsi namespace

### DIFF
--- a/assets/sip_samples/2D_fa307608-35c3-11ed-9243-7e92631d7d27/data/metadata/descriptive/dc+schema.xml
+++ b/assets/sip_samples/2D_fa307608-35c3-11ed-9243-7e92631d7d27/data/metadata/descriptive/dc+schema.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/">
 
 
 

--- a/assets/sip_samples/2D_fa307608-35c3-11ed-9243-7e92631d7d27/data/representations/representation_1/metadata/descriptive/dc+schema.xml
+++ b/assets/sip_samples/2D_fa307608-35c3-11ed-9243-7e92631d7d27/data/representations/representation_1/metadata/descriptive/dc+schema.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org">
 
     <!-- linking id between dc and premis -->
     <dcterms:identifier>uuid-187DA428-6BA1-4EB7-B786-CD4AF85A02B1</dcterms:identifier>

--- a/assets/sip_samples/2D_fa307608-35c3-11ed-9243-7e92631d7d27/data/representations/representation_2/metadata/descriptive/dc+schema.xml
+++ b/assets/sip_samples/2D_fa307608-35c3-11ed-9243-7e92631d7d27/data/representations/representation_2/metadata/descriptive/dc+schema.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org">
 
     <!-- linking id between dc and premis -->
     <dcterms:identifier>uuid-8DA0F75B-1031-4F20-B26C-184B919B1A43</dcterms:identifier>

--- a/assets/sip_samples/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/data/metadata/descriptive/dc+schema.xml
+++ b/assets/sip_samples/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/data/metadata/descriptive/dc+schema.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
 
 
   <!-- general title for the resource -->

--- a/assets/sip_samples/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/data/representations/representation_2/metadata/descriptive/dc+schema.xml
+++ b/assets/sip_samples/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/data/representations/representation_2/metadata/descriptive/dc+schema.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
 
     <!-- linking id between dc and premis -->
     <dcterms:identifier>uuid-7f16cfda-21ff-11ed-a277-7e92631d7d27</dcterms:identifier>

--- a/assets/sip_samples/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/data/representations/representation_3/metadata/descriptive/dc+schema.xml
+++ b/assets/sip_samples/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/data/representations/representation_3/metadata/descriptive/dc+schema.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
 
     <!-- linking id between dc and premis -->
     <dcterms:identifier>uuid-671f4eb6-21ff-11ed-9e92-7e92631d7d27</dcterms:identifier>

--- a/assets/sip_samples/basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec/data/metadata/descriptive/dc.xml
+++ b/assets/sip_samples/basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec/data/metadata/descriptive/dc.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <!-- linking id between dc and premis -->
   <dcterms:identifier>uuid-a0a5329c-4ad1-4607-9f6e-ce980d90b992</dcterms:identifier>

--- a/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/metadata/descriptive/dc_1.xml
+++ b/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/metadata/descriptive/dc_1.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 
   <!-- general title for the resource -->

--- a/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/metadata/descriptive/dc_2.xml
+++ b/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/metadata/descriptive/dc_2.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <!-- general title for the resource -->
     <dcterms:title>Felis Catus Flamens lying on a sofa</dcterms:title>

--- a/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/metadata/descriptive/dc_3.xml
+++ b/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/metadata/descriptive/dc_3.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <!-- general title for the resource -->
     <dcterms:title>Felis Catus Flamens sitting on a cat tree</dcterms:title>

--- a/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/representations/representation_1/metadata/descriptive/dc_1.xml
+++ b/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/representations/representation_1/metadata/descriptive/dc_1.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <!-- general title for the representation -->
   <dcterms:title>Colour representation of the Felis Catus Flamens lying on a sofa</dcterms:title>

--- a/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/representations/representation_2/metadata/descriptive/dc_1.xml
+++ b/assets/sip_samples/cbee2999-1db5-4a69-9260-f216dee75623/data/representations/representation_2/metadata/descriptive/dc_1.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <!-- general title for the representation -->
   <dcterms:title>Colour representation of the Felis Catus Flamens sitting on a cat tree</dcterms:title>

--- a/assets/sip_samples/mapping_ftp_sidecar/904c6e86-d36a-4630-897b-bb560ce4b690/data/metadata/descriptive/dc_1.xml
+++ b/assets/sip_samples/mapping_ftp_sidecar/904c6e86-d36a-4630-897b-bb560ce4b690/data/metadata/descriptive/dc_1.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:schema="http://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:schema="http://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <!-- velden obv. dcterms -->
   <!-- linking id between dc and premis -->

--- a/assets/sip_samples/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/data/metadata/descriptive/dc.xml
+++ b/assets/sip_samples/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/data/metadata/descriptive/dc.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <dcterms:title>Le Chat Blanc: 02/08/2022</dcterms:title>
 

--- a/assets/sip_samples/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/data/metadata/descriptive/mods.xml
+++ b/assets/sip_samples/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/data/metadata/descriptive/mods.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
 
   <mods:titleInfo>
     <mods:title>Le Chat Blanc</mods:title>

--- a/assets/sip_samples/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/data/metadata/descriptive/dc.xml
+++ b/assets/sip_samples/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/data/metadata/descriptive/dc.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <dcterms:title>Le Chat Blanc: 02/08/2022</dcterms:title>
 

--- a/assets/sip_samples/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/data/metadata/descriptive/mods.xml
+++ b/assets/sip_samples/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/data/metadata/descriptive/mods.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
 
   <mods:titleInfo>
     <mods:title>Le Chat Blanc</mods:title>

--- a/assets/sip_samples/subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6/data/metadata/descriptive/dc_1.xml
+++ b/assets/sip_samples/subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6/data/metadata/descriptive/dc_1.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <dcterms:title>the title of the episode</dcterms:title>
 

--- a/docs/diginstroom/sip/1.0/profiles/basic.md
+++ b/docs/diginstroom/sip/1.0/profiles/basic.md
@@ -242,7 +242,7 @@ Please note that additional IDs must be dealt with in the `preservation/premis.x
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 
   <!-- general title for the resource -->

--- a/docs/diginstroom/sip/1.0/usecases/single-file.md
+++ b/docs/diginstroom/sip/1.0/usecases/single-file.md
@@ -88,7 +88,7 @@ Note that the identifier is used to link the `dc.xml` file to the corresponding 
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <!-- general title for the resource -->
   <dcterms:title>Felis Catus Flamens sitting on a cat tree</dcterms:title>

--- a/docs/diginstroom/sip/1.0/usecases/video-with-subtitles.md
+++ b/docs/diginstroom/sip/1.0/usecases/video-with-subtitles.md
@@ -105,7 +105,7 @@ Note that the identifier is used to link the `dc.xml` file to the corresponding 
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <dcterms:title>the title of the episode</dcterms:title>
 

--- a/docs/diginstroom/sip/1.1/profiles/basic.md
+++ b/docs/diginstroom/sip/1.1/profiles/basic.md
@@ -244,7 +244,7 @@ Please note that additional IDs must be dealt with in the `preservation/premis.x
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 
   <!-- general title for the resource -->

--- a/docs/diginstroom/sip/1.1/usecases/2d-artwork.md
+++ b/docs/diginstroom/sip/1.1/usecases/2d-artwork.md
@@ -159,7 +159,7 @@ The identifier in the `<dcterms:identifier/>` element is used to link the `dc+sc
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org/">
 
   <!-- general title for the resource -->
   <dcterms:title xml:lang="nl">Bewening van Christus</dcterms:title>
@@ -337,7 +337,7 @@ The identifier is used to link the `dc+schema.xml` file to the corresponding PRE
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org">
 
     <!-- linking id between dc and premis -->
     <dcterms:identifier>uuid-187DA428-6BA1-4EB7-B786-CD4AF85A02B1</dcterms:identifier>

--- a/docs/diginstroom/sip/1.1/usecases/3d-scan.md
+++ b/docs/diginstroom/sip/1.1/usecases/3d-scan.md
@@ -183,7 +183,7 @@ The identifier is used to link the `dc+schema.xml` file to the corresponding PRE
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="">
 
 
   <!-- general title for the resource -->
@@ -463,7 +463,7 @@ The identifier is used to link the `dc+schema.xml` file to the corresponding PRE
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org/">
 
     <!-- linking id between dc and premis -->
     <dcterms:identifier>uuid-7f16cfda-21ff-11ed-a277-7e92631d7d27</dcterms:identifier>

--- a/docs/diginstroom/sip/1.1/usecases/gigapixel-artwork.md
+++ b/docs/diginstroom/sip/1.1/usecases/gigapixel-artwork.md
@@ -178,7 +178,7 @@ The identifier in the `<dcterms:identifier/>` element is used to link the `dc+sc
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:schema="https://schema.org/">
 
   <!-- general title for the resource -->
   <dcterms:title xml:lang="nl">Uur- en kalenderwijzeplaat</dcterms:title>

--- a/docs/diginstroom/sip/1.1/usecases/newspaper-pdf.md
+++ b/docs/diginstroom/sip/1.1/usecases/newspaper-pdf.md
@@ -143,7 +143,7 @@ Note that, as opposed to the `mods.xml` file, the `dc.xml` file is optional acco
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <dcterms:title>Le Chat Blanc: 02/08/2022</dcterms:title>
 
@@ -176,7 +176,7 @@ The examples below and in the sample mentioned earlier therefore only serve as a
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
 
   <mods:titleInfo>
     <mods:title>Le Chat Blanc</mods:title>

--- a/docs/diginstroom/sip/1.1/usecases/newspaper.md
+++ b/docs/diginstroom/sip/1.1/usecases/newspaper.md
@@ -129,7 +129,7 @@ Note that, as opposed to the `mods.xml` file, the `dc.xml` file is optional acco
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <dcterms:title>Le Chat Blanc: 02/08/2022</dcterms:title>
 
@@ -162,7 +162,7 @@ The examples below and in the sample mentioned earlier therefore only serve as a
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.7" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
 
   <mods:titleInfo>
     <mods:title>Le Chat Blanc</mods:title>

--- a/docs/diginstroom/sip/1.1/usecases/single-file.md
+++ b/docs/diginstroom/sip/1.1/usecases/single-file.md
@@ -90,7 +90,7 @@ Note that the identifier is used to link the `dc.xml` file to the corresponding 
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <!-- general title for the resource -->
   <dcterms:title>Felis Catus Flamens sitting on a cat tree</dcterms:title>

--- a/docs/diginstroom/sip/1.1/usecases/video-with-subtitles.md
+++ b/docs/diginstroom/sip/1.1/usecases/video-with-subtitles.md
@@ -107,7 +107,7 @@ Note that the identifier is used to link the `dc.xml` file to the corresponding 
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance/">
+<metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="https://schema.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <dcterms:title>the title of the episode</dcterms:title>
 


### PR DESCRIPTION
It should be "xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance", without the trailing space.