### PR TITLE
META-219 voeg eventoutcomeInformation toe aan premis:event

### DIFF
--- a/docs/diginstroom/sip/1.0/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/1.0/sip_structure/5_structure_package.md
@@ -1721,7 +1721,7 @@ TODO: figure out the IDs
             <premis:eventDetail />
         </premis:eventDetailInformation>
         <premis:eventOutcomeInformation>
-            <premis:eventOutcome>1</premis:eventOutcome>
+            <premis:eventOutcome valueURI="http://id.loc.gov/vocabulary/preservation/eventOutcome/suc">succes</premis:eventOutcome>
         </premis:eventOutcomeInformation>
         <premis:linkingAgentIdentifier>
             <premis:linkingAgentIdentifierType>OR-id</premis:linkingAgentIdentifierType>
@@ -1825,17 +1825,26 @@ TODO: figure out the IDs
 |-----------------------|-----------|
 | Name | Event outcome information  |
 | Description | Information about the outcome of an event. |
-| Cardinality | 0..1 |
+| Cardinality | 0..* |
 | Obligation | MAY |
 
 | Element | `premis:premis/premis:event/premis:eventOutcomeInformation/premis:eventOutcome` |
 |-----------------------|-----------|
 | Name | Event outcome  |
-| Description | This element categorizes the outcome of the event in terms of success or failure. It contains a value '0' (not successful) or '1' (successful) |
-| Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string) |
-| Vocabulary | `0`<br>`1` |
+| Description | This element categorizes the outcome of the event in terms of success or failure. |
+| Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string); fixed vocabulary (e.g. [`PREMIS event outcome`](https://id.loc.gov/vocabulary/preservation/eventOutcome.html)) |
+| Vocabulary | `fail`<br>`success`<br>`warning` |
 | Cardinality | 1..1 |
 | Obligation | MUST |
+
+| Attribute | `premis:premis/premis:event/premis:eventOutcomeInformation/premis:eventOutcome/@valueURI` |
+|-----------------------|-----------|
+| Name | Event outcome value URI  |
+| Description | This attribute references the URI that contains the specific entry from the authority/controlled vocabulary.<br><br>If the event outcome is `fail`, this attribute's value MUST be set to `http://id.loc.gov/vocabulary/preservation/eventOutcome/fai`.<br>If the event outcome is `success`, this attribute's value MUST be set to `http://id.loc.gov/vocabulary/preservation/eventOutcome/suc`.<br> If the event outcome is `warning`, this attribut's value MUST be set to `http://id.loc.gov/vocabulary/preservation/eventOutcome/war`.|
+| Datatype | [URI]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#uri); fixed vocabulary |
+| Vocabulary | `http://id.loc.gov/vocabulary/preservation/eventOutcome/fai`<br>`http://id.loc.gov/vocabulary/preservation/eventOutcome/suc`<br>`http://id.loc.gov/vocabulary/preservation/eventOutcome/war` |
+| Cardinality | 0..1 |
+| Obligation | MAY |
 
 | Element | `premis:premis/premis:event/premis:linkingAgentIdentifier` |
 |-----------------------|-----------|

--- a/docs/diginstroom/sip/1.0/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/1.0/sip_structure/5_structure_package.md
@@ -1720,6 +1720,9 @@ TODO: figure out the IDs
         <premis:eventDetailInformation>
             <premis:eventDetail />
         </premis:eventDetailInformation>
+        <premis:eventOutcomeInformation>
+            <premis:eventOutcome>1</premis:eventOutcome>
+        </premis:eventOutcomeInformation>
         <premis:linkingAgentIdentifier>
             <premis:linkingAgentIdentifierType>OR-id</premis:linkingAgentIdentifierType>
             <premis:linkingAgentIdentifierValue>OR-m30wc4t</premis:linkingAgentIdentifierValue>
@@ -1815,6 +1818,22 @@ TODO: figure out the IDs
 | Name | Event detail  |
 | Description | Additional information as unstructured text. Multiple details should be recorded in independent `premis:eventDetailInformation` containers instead of repeating the `premis:eventDetail` element. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string) |
+| Cardinality | 1..1 |
+| Obligation | MUST |
+
+| Element | `premis:premis/premis:event/premis:eventOutcomeInformation` |
+|-----------------------|-----------|
+| Name | Event outcome information  |
+| Description | Information about the outcome of an event. |
+| Cardinality | 0..1 |
+| Obligation | MAY |
+
+| Element | `premis:premis/premis:event/premis:eventOutcomeInformation/premis:eventOutcome` |
+|-----------------------|-----------|
+| Name | Event outcome  |
+| Description | This element categorizes the outcome of the event in terms of success or failure. It contains a value '0' (not successful) or '1' (successful) |
+| Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string) |
+| Vocabulary | `1`<br>`0` |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 

--- a/docs/diginstroom/sip/1.0/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/1.0/sip_structure/5_structure_package.md
@@ -1833,7 +1833,7 @@ TODO: figure out the IDs
 | Name | Event outcome  |
 | Description | This element categorizes the outcome of the event in terms of success or failure. It contains a value '0' (not successful) or '1' (successful) |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string) |
-| Vocabulary | `1`<br>`0` |
+| Vocabulary | `0`<br>`1` |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 

--- a/docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md
@@ -1835,7 +1835,7 @@ TODO: figure out the IDs
 | Name | Event outcome  |
 | Description | This element categorizes the outcome of the event in terms of success or failure. It contains a value '0' (not successful) or '1' (successful) |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string) |
-| Vocabulary | `1`<br>`0` |
+| Vocabulary | `0`<br>`1` |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 

--- a/docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md
@@ -1722,6 +1722,9 @@ TODO: figure out the IDs
         <premis:eventDetailInformation>
             <premis:eventDetail />
         </premis:eventDetailInformation>
+        <premis:eventOutcomeInformation>
+            <premis:eventOutcome>1</premis:eventOutcome>
+        </premis:eventOutcomeInformation>
         <premis:linkingAgentIdentifier>
             <premis:linkingAgentIdentifierType>OR-id</premis:linkingAgentIdentifierType>
             <premis:linkingAgentIdentifierValue>OR-m30wc4t</premis:linkingAgentIdentifierValue>
@@ -1817,6 +1820,22 @@ TODO: figure out the IDs
 | Name | Event detail  |
 | Description | Additional information as unstructured text. Multiple details should be recorded in independent `premis:eventDetailInformation` containers instead of repeating the `premis:eventDetail` element. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.1/2_terminology.md %}#string) |
+| Cardinality | 1..1 |
+| Obligation | MUST |
+
+| Element | `premis:premis/premis:event/premis:eventOutcomeInformation` |
+|-----------------------|-----------|
+| Name | Event outcome information  |
+| Description | Information about the outcome of an event. |
+| Cardinality | 0..1 |
+| Obligation | MAY |
+
+| Element | `premis:premis/premis:event/premis:eventOutcomeInformation/premis:eventOutcome` |
+|-----------------------|-----------|
+| Name | Event outcome  |
+| Description | This element categorizes the outcome of the event in terms of success or failure. It contains a value '0' (not successful) or '1' (successful) |
+| Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string) |
+| Vocabulary | `1`<br>`0` |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 

--- a/docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md
@@ -1723,7 +1723,7 @@ TODO: figure out the IDs
             <premis:eventDetail />
         </premis:eventDetailInformation>
         <premis:eventOutcomeInformation>
-            <premis:eventOutcome>1</premis:eventOutcome>
+            <premis:eventOutcome valueURI="http://id.loc.gov/vocabulary/preservation/eventOutcome/suc">succes</premis:eventOutcome>
         </premis:eventOutcomeInformation>
         <premis:linkingAgentIdentifier>
             <premis:linkingAgentIdentifierType>OR-id</premis:linkingAgentIdentifierType>
@@ -1827,17 +1827,26 @@ TODO: figure out the IDs
 |-----------------------|-----------|
 | Name | Event outcome information  |
 | Description | Information about the outcome of an event. |
-| Cardinality | 0..1 |
+| Cardinality | 0..* |
 | Obligation | MAY |
 
 | Element | `premis:premis/premis:event/premis:eventOutcomeInformation/premis:eventOutcome` |
 |-----------------------|-----------|
 | Name | Event outcome  |
-| Description | This element categorizes the outcome of the event in terms of success or failure. It contains a value '0' (not successful) or '1' (successful) |
-| Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.0/2_terminology.md %}#string) |
-| Vocabulary | `0`<br>`1` |
+| Description | This element categorizes the outcome of the event in terms of success or failure. |
+| Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/1.1/2_terminology.md %}#string); fixed vocabulary (e.g. [`PREMIS event outcome`](https://id.loc.gov/vocabulary/preservation/eventOutcome.html)) |
+| Vocabulary | `fail`<br>`success`<br>`warning` |
 | Cardinality | 1..1 |
 | Obligation | MUST |
+
+| Attribute | `premis:premis/premis:event/premis:eventOutcomeInformation/premis:eventOutcome/@valueURI` |
+|-----------------------|-----------|
+| Name | Event outcome value URI  |
+| Description | This attribute references the URI that contains the specific entry from the authority/controlled vocabulary.<br><br>If the event outcome is `fail`, this attribute's value MUST be set to `http://id.loc.gov/vocabulary/preservation/eventOutcome/fai`.<br>If the event outcome is `success`, this attribute's value MUST be set to `http://id.loc.gov/vocabulary/preservation/eventOutcome/suc`.<br> If the event outcome is `warning`, this attribut's value MUST be set to `http://id.loc.gov/vocabulary/preservation/eventOutcome/war`.|
+| Datatype | [URI]({{ site.baseurl }}{% link docs/diginstroom/sip/1.1/2_terminology.md %}#uri); fixed vocabulary |
+| Vocabulary | `http://id.loc.gov/vocabulary/preservation/eventOutcome/fai`<br>`http://id.loc.gov/vocabulary/preservation/eventOutcome/suc`<br>`http://id.loc.gov/vocabulary/preservation/eventOutcome/war` |
+| Cardinality | 0..1 |
+| Obligation | MAY |
 
 | Element | `premis:premis/premis:event/premis:linkingAgentIdentifier` |
 |-----------------------|-----------|


### PR DESCRIPTION
Zoals beloofd heb ik dit PREMIS element toegevoegd, maar misschien moet er toch wat meer diepgaand naar gekeken worden. `eventOutcome` vereist een zelf opgestelde gecontroleerde termenlijst om het success of failure aan te duiden. Bert stelde 0 (niet succesvol) en 1 (succesvol) voor, maar misschien is dat wat willekeurig? 

Als obligation stel ik MAY 0..1 voor. Volgens PREMIS kan je er ook meerdere hebben en zou 0..* ook mogelijk moeten zijn, maar het lijkt me raar dat iets zowel lukt als faalt. 

PREMIS voorziet ook nog een `eventOutcomeDetail(Note)` en dat is een vrijetekstveld. Zit er nu niet in. Dient bv. om warning en error messages in op te nemen.