### PR TITLE
META-286 Remove dc+schema in bibliographic profile

### DIFF
--- a/docs/diginstroom/sip/1.2/profiles/bibliographic.md
+++ b/docs/diginstroom/sip/1.2/profiles/bibliographic.md
@@ -26,8 +26,7 @@ root_directory
 └──data
     │──mets.xml
     │──metadata
-    |   |──descriptive      (at least one of both files must be present)
-    |   |  └──dc+schema.xml 
+    |   |──descriptive
     |   |  └──mods.xml
     |   └──preservation
     |       └──premis.xml
@@ -740,7 +739,6 @@ The XML files that are required by this profile can be validated using the follo
 | `mets.xml` | METS v1.22.1 | [mets.xsd](https://www.loc.gov/standards/mets/mets.xsd) |
 | `premis.xml` | PREMIS v3.0 | [premis-v3-0.xsd](https://www.loc.gov/standards/premis/v3/premis-v3-0.xsd) |
 | `mods.xml` | MODS v3.7 | [mods-3-7.xsd](https://www.loc.gov/standards/mods/v3/mods-3-7.xsd) |
-| `dc+schema.xml` (if no MODS) | Dublin Core (custom schema) | [dc_basic.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/dc_basic.xsd)<br>_depends on: [edtf.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/edtf.xsd), [dcterms.xsd](https://github.com/viaacode/sipin-sip-validator/blob/main/app/resources/xsd/dcterms.xsd), [dcmitype.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/dcmitype.xsd), [dc.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/dc.xsd)_ |
 
 ## Use Cases
 

--- a/docs/diginstroom/sip/1.2/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/1.2/sip_structure/5_structure_package.md
@@ -1406,7 +1406,7 @@ It also contains preservation metadata about the SIP as a whole.
 
 The `/descriptive` directory contains descriptive metadata about the IE(s) at the package level.
 This descriptive metadata is stored in different XML files, depending on the number of IE(s) present in the SIP.
-Examples are `dc+schema.xml`, `mods.xml` and `dc+schema.xml`.
+Examples are `mods.xml` and `dc+schema.xml`.
 These files apply a certain metadata schema, such as [DCTERMS](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/) or [MODS](https://www.loc.gov/standards/mods/).
 The concrete requirements of descriptive metadata files and the applied metadata schemas are defined by the [content profiles]({{ site.baseurl }}{% link docs/diginstroom/sip/1.2/profiles/index.md %}).
 

--- a/docs/diginstroom/sip/1.2/usecases/newspaper-pdf.md
+++ b/docs/diginstroom/sip/1.2/usecases/newspaper-pdf.md
@@ -184,7 +184,7 @@ The examples below and in the sample mentioned earlier therefore only serve as a
 The `premis.xml` of the package level describes the IE and the relationships with its representations.
 It also contains two PREMIS events: a transcription event that details how the ALTO XML was created from the TIFF files using OCR, and a creation event that details how the PDF was created from the ALTO XML and TIFF files.
 
-Note that the identifier in the `<premis:objectIdentifier>` element is shared with the `<dcterms:identifier/>` (in the `descriptive/dc+schema.xml` file) and with the `<mods:identifier/>` (in the `descriptive/mods.xml` file) in order to link the PREMIS IE object to its descriptions in the two files.
+Note that the identifier in the `<premis:objectIdentifier>` element is shared with the `<mods:identifier/>` (in the `descriptive/mods.xml` file) in order to link the PREMIS IE object to its descriptions in the two files.
 
 
 ```xml

--- a/docs/diginstroom/sip/2.0/profiles/bibliographic.md
+++ b/docs/diginstroom/sip/2.0/profiles/bibliographic.md
@@ -22,7 +22,7 @@ It applies the [MODS XML metadata schema](https://www.loc.gov/standards/mods/) f
 root_directory
 │──mets.xml
 │──metadata
-|   |──descriptive      (at least one of both files must be present)
+|   |──descriptive
 |   |  └──mods.xml
 |   └──preservation
 |       └──premis.xml


### PR DESCRIPTION
The bibliographic profile only allows `mods.xml` as descriptive metadata. Remove some lingering references to `dc+schema.xml`.