### PR TITLE
SIP-12 Change mets.xml to METS.xml

### DIFF
--- a/docs/diginstroom/sip/2.0/2_terminology.md
+++ b/docs/diginstroom/sip/2.0/2_terminology.md
@@ -30,13 +30,13 @@ Editor's Draft
     <dt>Package</dt>
     <dd>The middle layer of the meemoo SIP. It consists of a number of directories and metadata files, containing the lowest (i.e. representation) layer of the meemoo SIP.</dd>
     <dt>Package METS</dt>
-    <dd>The metadata file conforming to the <a href="https://www.loc.gov/standards/mets/mets.xsd">METS standard</a> situated at the package level of the SIP (i.e. at <code>/data/mets.xml</code>)</dd>
+    <dd>The metadata file conforming to the <a href="https://www.loc.gov/standards/mets/mets.xsd">METS standard</a> situated at the package level of the SIP (i.e. at <code>/data/METS.xml</code>)</dd>
     <dt>Preservation metadata</dt>
     <dd>Metadata about the context and structure of a digital object. It is an essential part of current digital preservation strategies and data management. Examples include file size, the checksum of a file and how/when the file was created.</dd>
     <dt>Representation</dt>
     <dd>A set of files (including metadata) needed for a complete rendition of an IE. Note that an IE can be represented by multiple representations (e.g. a high quality representation and a low quality representation).</dd>
     <dt>Representation METS</dt>
-    <dd>The metadata file conforming to the <a href="https://www.loc.gov/standards/mets/mets.xsd">METS standard</a> situated at one of the different representation directories of the representation level of the SIP (e.g. at <code>/data/representation/representation_1/mets.xml</code>)</dd>
+    <dd>The metadata file conforming to the <a href="https://www.loc.gov/standards/mets/mets.xsd">METS standard</a> situated at one of the different representation directories of the representation level of the SIP (e.g. at <code>/data/representation/representation_1/METS.xml</code>)</dd>
     <dt>Sidecar</dt>
     <dd>An alternative term for a file exclusively containing metadata.</dd>
     <dt>Structural metadata</dt>

--- a/docs/diginstroom/sip/2.0/profiles/basic.md
+++ b/docs/diginstroom/sip/2.0/profiles/basic.md
@@ -18,7 +18,7 @@ The basic profile supports simple cases consisting of a single media file accomp
 
 ```plaintext
 root_directory
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -27,7 +27,7 @@ root_directory
 │
 └── representations
     └──representation_1
-        │── mets.xml
+        │── METS.xml
         └──data
         |  |── file_1.xyz
         │  └── ...
@@ -499,7 +499,7 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 The XML files that are required by this profile can be validated using the following XML schema definitions:
 
 | File | Format | XML Schema |
-| `mets.xml` | METS v1.12.1 | [mets.xsd](https://www.loc.gov/standards/mets/mets.xsd) |
+| `METS.xml` | METS v1.12.1 | [mets.xsd](https://www.loc.gov/standards/mets/mets.xsd) |
 | `premis.xml` | PREMIS v3.0 | [premis-v3-0.xsd](https://www.loc.gov/standards/premis/v3/premis-v3-0.xsd) |
 | `dc+schema.xml` | Dublin Core (custom schema) | [dc_basic.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/dc_basic.xsd)<br>_depends on: [edtf.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/edtf.xsd), [dcterms.xsd](https://github.com/viaacode/sipin-sip-validator/blob/main/app/resources/xsd/dcterms.xsd), [dcmitype.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/dcmitype.xsd), [dc.xsd](https://raw.githubusercontent.com/viaacode/sipin-sip-validator/main/app/resources/xsd/dc.xsd)_|
 

--- a/docs/diginstroom/sip/2.0/profiles/bibliographic.md
+++ b/docs/diginstroom/sip/2.0/profiles/bibliographic.md
@@ -20,7 +20,7 @@ It applies the [MODS XML metadata schema](https://www.loc.gov/standards/mods/) f
 
 ```plaintext
 root_directory
-│──mets.xml
+│──METS.xml
 │──metadata
 |   |──descriptive
 |   |  └──mods.xml
@@ -29,7 +29,7 @@ root_directory
 │
 └──representations
 │──representation_1
-│    │──mets.xml
+│    │──METS.xml
 │    │──data
 │    |   |──file_1.tiff
 │    │   └──...
@@ -39,7 +39,7 @@ root_directory
 │            └──premis.xml
 │
 │──representation_2
-│    │──mets.xml
+│    │──METS.xml
 │    │──data
 │    |   |──file_1.xml
 │    │   └──...
@@ -49,7 +49,7 @@ root_directory
 │          └──premis.xml
 │
 └──representation_3
-    │──mets.xml
+    │──METS.xml
     │──data
     |  └── file_1.pdf
     │
@@ -732,7 +732,7 @@ root_directory
 The XML files that are required by this profile can be validated using the following XML schema definitions:
 
 | File | Format | XML Schema |
-| `mets.xml` | METS v1.12.1 | [mets.xsd](https://www.loc.gov/standards/mets/mets.xsd) |
+| `METS.xml` | METS v1.12.1 | [mets.xsd](https://www.loc.gov/standards/mets/mets.xsd) |
 | `premis.xml` | PREMIS v3.0 | [premis-v3-0.xsd](https://www.loc.gov/standards/premis/v3/premis-v3-0.xsd) |
 | `mods.xml` | MODS v3.7 | [mods-3-7.xsd](https://www.loc.gov/standards/mods/v3/mods-3-7.xsd) |
 

--- a/docs/diginstroom/sip/2.0/profiles/index.md
+++ b/docs/diginstroom/sip/2.0/profiles/index.md
@@ -16,7 +16,7 @@ They group different types of content that share a similar structure (e.g., ther
 
 A profile adds extra restrictions or extensions on top of the SIP specification.
 Hence, the SIP validation process depends on both.
-A delivered SIP MUST indicate which profile it adheres to in the package `mets.xml` through the [`mets/@csip:OTHERCONTENTINFORMATIONTYPE` attribute]({{ site.baseurl }}{% link docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md %}#OTHERCONTENTINFORMATIONTYPE). Note that the `csip:CONTENTINFORMATIONTYPE` attribute must always be set to `OTHER`.
+A delivered SIP MUST indicate which profile it adheres to in the package `METS.xml` through the [`mets/@csip:OTHERCONTENTINFORMATIONTYPE` attribute]({{ site.baseurl }}{% link docs/diginstroom/sip/1.1/sip_structure/5_structure_package.md %}#OTHERCONTENTINFORMATIONTYPE). Note that the `csip:CONTENTINFORMATIONTYPE` attribute must always be set to `OTHER`.
 
 <small>
 Continue to [Basic profile]({{ site.baseurl }}{% link docs/diginstroom/sip/1.1/profiles/basic.md %}).

--- a/docs/diginstroom/sip/2.0/profiles/material-artwork.md
+++ b/docs/diginstroom/sip/2.0/profiles/material-artwork.md
@@ -24,7 +24,7 @@ It also allows extensions to the descriptive metadata using [Schema.org](https:/
 
 ```plaintext
 root_directory
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -33,7 +33,7 @@ root_directory
 │
 └── representations
    └──representation_1       # overview with frame
-      │── mets.xml
+      │── METS.xml
       └──data
       │  └── PID_overzichtsopname_metlijst_tiff.tiff
       │
@@ -43,7 +43,7 @@ root_directory
          └──preservation
             └── premis.xml
    └──representation_2       # overview without frame
-      │── mets.xml
+      │── METS.xml
       └──data
       │  └── PID_overzichtsopname_zonderlijst_tiff.tif
       │
@@ -53,7 +53,7 @@ root_directory
          └──preservation
             └── premis.xml
    └──representation_3       # composed stitch 
-      │── mets.xml
+      │── METS.xml
       └──data
       │  └── PID_stitch_tiff.tif
       │
@@ -63,7 +63,7 @@ root_directory
          └──preservation
             └── premis.xml
    └──representation_4       # stitch 
-      │── mets.xml
+      │── METS.xml
       └──data
       |  |── PID_deelopname1_tiff.tif
       |  |── PID_deelopname2_tiff.tif
@@ -80,7 +80,7 @@ root_directory
 
 ```plaintext
 root_directory
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -89,7 +89,7 @@ root_directory
 │
 └── representations
    └──representation_1       # high-poly capture for print
-      │── mets.xml
+      │── METS.xml
       └──data  
       │  └── PID_ARCH_STL.STL              
       │
@@ -99,7 +99,7 @@ root_directory
          └──preservation
             └── premis.xml
    └──representation_2       # high-poly capture
-      │── mets.xml
+      │── METS.xml
       └──data
       |  |── PID_ARCH_OBJ.OBJ       # polygon file    
       |  |── PID_ARCH_TIFF_COLOR.TIFF      # texture image       
@@ -111,7 +111,7 @@ root_directory
          └──preservation
             └── premis.xml
    └──representation_3       # low-poly capture
-      │── mets.xml
+      │── METS.xml
       └──data
       |  |── PID_VER_OBJ.OBJ       # polygon file    
       |  |── PID_VER_COLOR_BMP.BMP             # texture image       
@@ -123,7 +123,7 @@ root_directory
          └──preservation
             └── premis.xml
    └──representation_4       # quality assessment reference
-      │── mets.xml
+      │── METS.xml
       └──data
       |  |── PID_REF_OBJ.OBJ               # polygon file    
       |  |── PID_REF_BMP.BMP               # texture image      
@@ -154,7 +154,7 @@ root_directory
 ### Package METS
 
 - The `csip:CONTENTINFORMATIONTYPE` attribute MUST be set to `OTHER` and the `csip:OTHERCONTENTINFORMATIONTYPE` attribute MUST be set to `https://data.hetarchief.be/id/sip/2.0/material-artwork`.
-- The `TYPE` attribute in the `mets.xml` file MUST be set to
+- The `TYPE` attribute in the `METS.xml` file MUST be set to
   - `Photographs - Digital` (for 2D objects) or
   - `Scanned 3D Objects (output from photogrammetry scanning)` (for 3D objects).
 - The `mets/dmdSec/mdRef/@MDTYPE` attribute MUST be set to `OTHER` and `mets/dmdSec/mdRef/@OTHERMDTYPE` attribute must be set to `DC+SCHEMA`.
@@ -174,7 +174,7 @@ root_directory
 The XML files that are required by this profile can be validated using the following XML schema definitions:
 
 | File | Format | XML Schema |
-| `mets.xml` | METS v1.12.1 | [mets.xsd](https://www.loc.gov/standards/mets/mets.xsd) |
+| `METS.xml` | METS v1.12.1 | [mets.xsd](https://www.loc.gov/standards/mets/mets.xsd) |
 | `premis.xml` | PREMIS v3.0 | [premis-v3-0.xsd](https://www.loc.gov/standards/premis/v3/premis-v3-0.xsd) |
 | `dc+schema.xml` | Dublin Core with Schema.org | dc+schema.xsd (not yet available) |
 

--- a/docs/diginstroom/sip/2.0/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/2.0/sip_structure/5_structure_package.md
@@ -44,7 +44,7 @@ root_directory
 
 ***Requirements***
 
-- The root directory MUST contain exactly one `METS.xml` file.
+- The root directory MUST contain exactly one `METS.xml` file. The word `METS` in the filename MUST be written in all caps as displayed here.
 - The root directory MUST have the value of the `OBJID` attribute in the `METS.xml` header as directory name. See [`mets/@OBJID`](#OBJID) for more details.
 - The root directory MUST contain exactly one `/metadata` directory.
 - The root directory MUST contain exactly one `/representations` directory.

--- a/docs/diginstroom/sip/2.0/sip_structure/5_structure_package.md
+++ b/docs/diginstroom/sip/2.0/sip_structure/5_structure_package.md
@@ -17,7 +17,7 @@ Editor's Draft
 1. TOC
 {:toc}
 
-The package level is the top level of the meemoo SIP and consists of at least a `mets.xml` file, a `/metadata` directory and a `/representations` directory.
+The package level is the top level of the meemoo SIP and consists of at least a `METS.xml` file, a `/metadata` directory and a `/representations` directory.
 It contains information about the IE(s) of the SIP and the SIP as a whole.
 
 The package level may contain a `/documentation` and a `/schemas` directory.
@@ -28,7 +28,7 @@ These two directories are ignored during ingest and will therefore not be archiv
 
 ```plaintext
 root_directory
-└──mets.xml
+└──METS.xml
 │
 └──metadata
 │  │
@@ -44,34 +44,34 @@ root_directory
 
 ***Requirements***
 
-- The root directory MUST contain exactly one `mets.xml` file.
-- The root directory MUST have the value of the `OBJID` attribute in the `mets.xml` header as directory name. See [`mets/@OBJID`](#OBJID) for more details.
+- The root directory MUST contain exactly one `METS.xml` file.
+- The root directory MUST have the value of the `OBJID` attribute in the `METS.xml` header as directory name. See [`mets/@OBJID`](#OBJID) for more details.
 - The root directory MUST contain exactly one `/metadata` directory.
 - The root directory MUST contain exactly one `/representations` directory.
 - The root directory MAY contain exactly one `/documentation` directory.
 - The root directory MAY contain exactly one `/schemas` directory.
 
-## mets.xml (file)
+## METS.xml (file)
 
 [Metadata Encoding and Transmission Standard](https://www.loc.gov/standards/mets/mets-home.html) (METS) is a metadata standard for encoding descriptive, administrative and structural metadata.
-In the case of the meemoo SIP, the `mets.xml` file's main purpose is to act as an inventory of the files and directories contained within.
+In the case of the meemoo SIP, the `METS.xml` file's main purpose is to act as an inventory of the files and directories contained within.
 Since it is situated at the package-level, it is also known as the _package METS file_.
 
-It should not be confused with the `mets.xml` files situated in their respective [representation folders](./6_structure_representation.html).
-The package `mets.xml` file does not record the internal structure of the different representations in the `/representations` directory.
-It only references the different `mets.xml` files contained in each `/representation_*` directory (where `*` is an integer indicating the number of different representations in the `/representation` directory).
-Each of the `mets.xml` files at the [representation level](./6_structure_representation.html) references its own internal structure.
+It should not be confused with the `METS.xml` files situated in their respective [representation folders](./6_structure_representation.html).
+The package `METS.xml` file does not record the internal structure of the different representations in the `/representations` directory.
+It only references the different `METS.xml` files contained in each `/representation_*` directory (where `*` is an integer indicating the number of different representations in the `/representation` directory).
+Each of the `METS.xml` files at the [representation level](./6_structure_representation.html) references its own internal structure.
 
 ### Elements and internal references
 
-A `mets.xml` file typically consists of a number of fixed elements, outlined below.
+A `METS.xml` file typically consists of a number of fixed elements, outlined below.
 Each of these elements is covered in a dedicated subsection in the remainder of this section.
 
 - `<mets>` element: the root tag; this element contains a number of attributes with information about the type of SIP and its identification.
 - `<metsHdr>` element: this tag mainly covers the agents (such as software or the CP) involved with the creation and submission process of the SIP.
 - `<dmdSec>` element: this tag contains descriptive metadata, either embedded within the tag or with a reference to an external metadata file.
 - `<amdSec>` element: this tag contains preservation metadata, either embedded within the tag or with a reference to an external metadata file.
-- `<fileSec>` element: this tag acts as an inventory of the files that comprise the digital object being described in the `mets.xml` file.
+- `<fileSec>` element: this tag acts as an inventory of the files that comprise the digital object being described in the `METS.xml` file.
 - `<structMap>` element: this tag organizes the digital content represented in the `<fileSec>`, `<dmdSec>`, and `<amdSec>` elements into a coherent hierarchical structure. This is important for a correct comprehension and navigation of digital content with complex relationships between the digital objects, such as newspapers. 
 
 Some of these elements, or their child elements, are identified with an identifier, contained in the `@ID` attribute (see the requirements in the sections below).
@@ -82,8 +82,8 @@ Therefore, it contains pointers to the `@ID` identifiers defined in the `<fileSe
 An overview of the different elements and references on the package level is given in the following figure.
 
 <figure class="mx-auto">
-  <img src="../../../../../assets/images_spec/sip-package-pointers.svg" alt="Internal references between elements in the package mets.xml" /> 
-  <figcaption>Internal references between elements in the mets.xml.</figcaption>
+  <img src="../../../../../assets/images_spec/sip-package-pointers.svg" alt="Internal references between elements in the package METS.xml" /> 
+  <figcaption>Internal references between elements in the METS.xml.</figcaption>
 </figure>
 
 In addition, 
@@ -822,7 +822,7 @@ This means that the `amdSec` MUST use `<mdRef>` elements, contained in `<digipro
 <!-- | Element | `mets/amdSec/rightsMD` |
 |-----------------------|-----------|
 | Name | Rights metadata |
-| Description | A simple rights statement may be used to describe general permissions for the package.<br><br>Individual representations SHOULD state their specific rights in their representation `mets.xml` file.<br>Standards for rights metadata include [RightsStatements.org](http://rightsstatements.org/), [Europeana rights statements info](https://pro.europeana.eu/page/available-rights-statements), [METS Rights Schema](https://github.com/mets/METS-Rights-Schema) and [PREMIS Rights Entities](https://www.loc.gov/standards/premis/v3/premis-3-0-final.pdf#page=188).|
+| Description | A simple rights statement may be used to describe general permissions for the package.<br><br>Individual representations SHOULD state their specific rights in their representation `METS.xml` file.<br>Standards for rights metadata include [RightsStatements.org](http://rightsstatements.org/), [Europeana rights statements info](https://pro.europeana.eu/page/available-rights-statements), [METS Rights Schema](https://github.com/mets/METS-Rights-Schema) and [PREMIS Rights Entities](https://www.loc.gov/standards/premis/v3/premis-3-0-final.pdf#page=188).|
 | Cardinality | 0..* |
 | Obligation | MAY |
 
@@ -845,7 +845,7 @@ This means that the `amdSec` MUST use `<mdRef>` elements, contained in `<digipro
 
 | Element | `mets/amdSec/rightsMD/mdRef` |
 |-----------------------|-----------|
-| Name | Reference to the document with the rights metadata (when not embedded within the mets.xml file). |
+| Name | Reference to the document with the rights metadata (when not embedded within the METS.xml file). |
 | Description | Reference to the rights metadata file(s) when located in the `/metadata/preservation` directory. |
 | Cardinality | 1..1 |
 | Obligation | MUST |
@@ -926,8 +926,8 @@ This means that the `amdSec` MUST use `<mdRef>` elements, contained in `<digipro
 ### \<fileSec\> section
 
 The `fileSec` element (short for 'file section') lists all files of the package level in the SIP.
-It contains references to the representation `mets.xml` files of the different representations, but does not list other files of those representations.
-The listing of other representation files (i.e. metadata files and media files) is left to the respective representation `mets.xml` files.
+It contains references to the representation `METS.xml` files of the different representations, but does not list other files of those representations.
+The listing of other representation files (i.e. metadata files and media files) is left to the respective representation `METS.xml` files.
 
 ***Example***
 
@@ -936,12 +936,12 @@ The listing of other representation files (i.e. metadata files and media files) 
 <fileSec ID="uuid-0c53fd9b-f640-4def-a872-2e4622f691d9">
   <fileGrp USE="Representations/representation_1" ID="uuid-700c97da-3164-4863-9e58-d6d62156052e">
       <file ID="uuid-0fe40ffc-b5f3-465e-af3a-d266d94453b7" MIMETYPE="text/xml" SIZE="4264" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="297f0482f32b2836d2ac7e2ff0a5884d" CHECKSUMTYPE="MD5">
-          <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/mets.xml" />
+          <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/METS.xml" />
       </file>
   </fileGrp>
   <fileGrp USE="Representations/representation_2" ID="uuid-c0fed1c6-96c8-4f15-9e82-abc7be2e981c">
       <file ID="uuid-625629a4-e5f8-4087-9114-66e4a943bf50" MIMETYPE="text/xml" SIZE="3865" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="95cd90cad81c9227f76d5f584182b308" CHECKSUMTYPE="MD5">
-          <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_2/mets.xml" />
+          <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_2/METS.xml" />
       </file>
   </fileGrp>
 </fileSec>
@@ -949,9 +949,9 @@ The listing of other representation files (i.e. metadata files and media files) 
 
 ***Requirements***
 
-- There MUST NOT be more than one `fileSec` element in the `mets.xml` file.
-- The `fileSec` element of the package `mets.xml` file MUST NOT reference anything from the different representation levels, EXCEPT the representation `mets.xml` files.
-- Each representation `mets.xml` MUST be referenced within its own `fileGrp` element within the `fileSec` element of the package `mets.xml`.
+- There MUST NOT be more than one `fileSec` element in the `METS.xml` file.
+- The `fileSec` element of the package `METS.xml` file MUST NOT reference anything from the different representation levels, EXCEPT the representation `METS.xml` files.
+- Each representation `METS.xml` MUST be referenced within its own `fileGrp` element within the `fileSec` element of the package `METS.xml`.
 
 | Element | `mets/fileSec` |
 |-----------------------|-----------|
@@ -987,7 +987,7 @@ The listing of other representation files (i.e. metadata files and media files) 
 | Attribute | `mets/fileSec/fileGrp[@USE=[starts-with('Representations')]]` |
 |-----------------------|-----------|
 | Name | Representations file group |
-| Description | A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with `mets/fileSec/fileGrp/@USE` attribute value starting with `Representations` followed by the path to the folder where the _representation level_ `mets.xml` file is placed. |
+| Description | A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with `mets/fileSec/fileGrp/@USE` attribute value starting with `Representations` followed by the path to the folder where the _representation level_ `METS.xml` file is placed. |
 | Cardinality | 1..* |
 | Obligation | MUST |
 
@@ -1152,10 +1152,10 @@ It provides links between elements and metadata files located elsewhere in the p
             DMDID="uuid-c6a678a7-b4b0-45af-a7d4-33123d9f0911 uuid-7a3443ed-9925-414b-819f-fc4830475e22 uuid-dff9e2ad-ab58-490a-9d80-df6c812404d2"
             ADMID="uuid-4ac13924-fe19-4711-b51f-6b5acc692ec0" />
         <div ID="uuid-c5cab13b-aced-4024-bbc3-d38c682602d2" LABEL="Representations/representation_1">
-            <mptr xlink:type="simple" xlink:href="./representations/representation_1/mets.xml" LOCTYPE="URL" xlink:title="uuid-700c97da-3164-4863-9e58-d6d62156052e" />
+            <mptr xlink:type="simple" xlink:href="./representations/representation_1/METS.xml" LOCTYPE="URL" xlink:title="uuid-700c97da-3164-4863-9e58-d6d62156052e" />
         </div>
         <div ID="uuid-daeba358-46ee-4363-b2a2-bd745c128f6f" LABEL="Representations/representation_2">
-            <mptr xlink:type="simple" xlink:href="./representations/representation_2/mets.xml" LOCTYPE="URL" xlink:title="uuid-c0fed1c6-96c8-4f15-9e82-abc7be2e981c" />
+            <mptr xlink:type="simple" xlink:href="./representations/representation_2/METS.xml" LOCTYPE="URL" xlink:title="uuid-c0fed1c6-96c8-4f15-9e82-abc7be2e981c" />
         </div>
     </div>
 </structMap>
@@ -1330,7 +1330,7 @@ It provides links between elements and metadata files located elsewhere in the p
 | Element | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations/representation_*']` |
 |-----------------------|-----------|
 | Name | Representation division |
-| Description | A package consists of multiple representations, each described by a representation level `mets.xml` file, there should be a discrete representation `\div` element for each representation. <br> Each representation `div` references the representation level `mets.xml` file, documenting the structure of the representation and its content. |
+| Description | A package consists of multiple representations, each described by a representation level `METS.xml` file, there should be a discrete representation `\div` element for each representation. <br> Each representation `div` references the representation level `METS.xml` file, documenting the structure of the representation and its content. |
 | Cardinality | 1..* |
 | Obligation | MUST |
 
@@ -1345,7 +1345,7 @@ It provides links between elements and metadata files located elsewhere in the p
 | Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations/representation_*']/@LABEL` |
 |-----------------------|-----------|
 | Name | Representations division label |
-| Description | The package’s representation division `div` element `@LABEL` attribute value must be the path to the representation level `mets.xml` file starting with the value `Representations` followed by the main folder name, e.g. `Representations/representation_1`. |
+| Description | The package’s representation division `div` element `@LABEL` attribute value must be the path to the representation level `METS.xml` file starting with the value `Representations` followed by the main folder name, e.g. `Representations/representation_1`. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/2_terminology.md %}#string) |
 | Cardinality | 1..1 |
 | Obligation | MUST |
@@ -1353,7 +1353,7 @@ It provides links between elements and metadata files located elsewhere in the p
 | Element | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations/representation_*']/mptr` |
 |-----------------------|-----------|
 | Name | Representation METS pointer |
-| Description | The division `div` of the specific representation includes one occurrence of the METS pointer `mptr` element, pointing to the appropriate representation `mets.xml` file. |
+| Description | The division `div` of the specific representation includes one occurrence of the METS pointer `mptr` element, pointing to the appropriate representation `METS.xml` file. |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 
@@ -1368,7 +1368,7 @@ It provides links between elements and metadata files located elsewhere in the p
 | Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations/representation_*']/mptr/@xlink:href` |
 |-----------------------|-----------|
 | Name | Resource location |
-| Description | Indication of the actual location of the `mets.xml` file.<br>As indicated by the `@LOCTYPE` attribute, this filepath MUST be a URL type filepath.<br>One SHOULD use the relative location of the file in this URL. |
+| Description | Indication of the actual location of the `METS.xml` file.<br>As indicated by the `@LOCTYPE` attribute, this filepath MUST be a URL type filepath.<br>One SHOULD use the relative location of the file in this URL. |
 | Datatype | [URL]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/2_terminology.md %}#url) |
 | Cardinality | 1..1 |
 | Obligation | MUST |
@@ -1384,7 +1384,7 @@ It provides links between elements and metadata files located elsewhere in the p
 | Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations/representation_*']/mptr[@LOCTYPE='URL']` |
 |-----------------------|-----------|
 | Name | Type of locator |
-| Description | Indication of the locator type used to refer to the representation mets.xml files of the different representation levels.<br>It MUST always be used with the value `URL`. |
+| Description | Indication of the locator type used to refer to the representation METS.xml files of the different representation levels.<br>It MUST always be used with the value `URL`. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/2_terminology.md %}#string) |
 | Cardinality | 1..1 |
 | Obligation | MUST |

--- a/docs/diginstroom/sip/2.0/sip_structure/6_structure_representation.md
+++ b/docs/diginstroom/sip/2.0/sip_structure/6_structure_representation.md
@@ -61,7 +61,7 @@ These two directories are ignored during ingest and will therefore not be archiv
 
 ***Requirements***
 
-- A `/representation_*` directory MUST contain exactly one `METS.xml` file.
+- A `/representation_*` directory MUST contain exactly one `METS.xml` file. The word `METS` in the filename MUST be written in all caps as displayed here.
 - A `/representation_*` directory MUST contain exactly one `/metadata` directory.
 - A `/representation_*` directory MUST contain exactly one `/data` directory.
 - A `/representation_*` directory MAY contain exactly one `/documentation` directory.

--- a/docs/diginstroom/sip/2.0/sip_structure/6_structure_representation.md
+++ b/docs/diginstroom/sip/2.0/sip_structure/6_structure_representation.md
@@ -29,7 +29,7 @@ root_directory
 └──representations
    │
    └──representation_1
-   │  │── mets.xml
+   │  │── METS.xml
    │  │
    │  └──data
    │  │  │   ...
@@ -50,10 +50,10 @@ root_directory
 
 ## /representation_* (directory)
 
-A `/representation_*` directory consists of at least a `mets.xml` file, a `/data` directory and a `/metadata` directory.
+A `/representation_*` directory consists of at least a `METS.xml` file, a `/data` directory and a `/metadata` directory.
 It contains both descriptive and preservation metadata, as well as the actual media files making up a certain representation of the IE(s) of the SIP.
 
-Each `/representation_*` directory contains its own `mets.xml` file which acts similarly as the package `mets.xml` and serves as an inventory of the files and directories of the representation level.
+Each `/representation_*` directory contains its own `METS.xml` file which acts similarly as the package `METS.xml` and serves as an inventory of the files and directories of the representation level.
 
 A `/representation_*` directory may contain a `/documentation` and a `/schemas` directory. 
 The former may contain additional information aiding the interpretation of the representation, while the latter may contain XML Schema Definition (XSD) files of the metadata schemas used in the representation.
@@ -61,19 +61,19 @@ These two directories are ignored during ingest and will therefore not be archiv
 
 ***Requirements***
 
-- A `/representation_*` directory MUST contain exactly one `mets.xml` file.
+- A `/representation_*` directory MUST contain exactly one `METS.xml` file.
 - A `/representation_*` directory MUST contain exactly one `/metadata` directory.
 - A `/representation_*` directory MUST contain exactly one `/data` directory.
 - A `/representation_*` directory MAY contain exactly one `/documentation` directory.
 - A `/representation_*` directory MAY contain exactly one `/schemas` directory.
 
-## mets.xml (file)
+## METS.xml (file)
 
-The `mets.xml` file at the representation level (also known as the representation mets) generally follows the same structure and requirements as the package mets discussed in the section [package mets.xml](./5_structure_package.html#metsxml-file).
+The `METS.xml` file at the representation level (also known as the representation mets) generally follows the same structure and requirements as the package mets discussed in the section [package METS.xml](./5_structure_package.html#metsxml-file).
 
 ### Elements and internal references
 
-Since the `dmdSec`, `amdSec`, `fileSec` sections follow the same requirements, where possible, as the package `mets.xml` file,  only lists (additional) requirements regarding the `mets`, `metsHdr` and `structMap` sections are covered in a dedicated subsection in the remainder of this section.
+Since the `dmdSec`, `amdSec`, `fileSec` sections follow the same requirements, where possible, as the package `METS.xml` file,  only lists (additional) requirements regarding the `mets`, `metsHdr` and `structMap` sections are covered in a dedicated subsection in the remainder of this section.
 
 Some of these elements, or their child elements, are identified with an identifier, contained in the `@ID` attribute (see the requirements in the sections below).
 These identifiers must be unique within the SIP. 
@@ -83,8 +83,8 @@ Therefore, it contains pointers to the `@ID` identifiers defined in the `<fileSe
 An overview of the different elements and references on the representation level is given in the following figure.
 
 <figure class="mx-auto">
-  <img src="../../../../../assets/images_spec/sip-representation-pointers.svg" alt="Internal references between elements in the mets.xml" /> 
-  <figcaption>Internal references between elements in the representation mets.xml.</figcaption>
+  <img src="../../../../../assets/images_spec/sip-representation-pointers.svg" alt="Internal references between elements in the METS.xml" /> 
+  <figcaption>Internal references between elements in the representation METS.xml.</figcaption>
 </figure>
 
 In addition, 
@@ -322,7 +322,7 @@ Depending on the use-case and the CP, these files can be digital pictures, video
 ***Requirements***
 
 - The `/data` directory MUST NOT contain any subdirectories.
-- All files in the `/data` directory MUST be referenced in the corresponding representation `mets.xml` file.
+- All files in the `/data` directory MUST be referenced in the corresponding representation `METS.xml` file.
 
 ## /metadata (directory)
 

--- a/docs/diginstroom/sip/2.0/sip_structure/index.md
+++ b/docs/diginstroom/sip/2.0/sip_structure/index.md
@@ -22,10 +22,10 @@ The meemoo SIP consists of a hierarchical directory structure with 2 levels:
 </figure>
 
 The [_package level_]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/sip_structure/5_structure_package.md %}) contains descriptive and preservation information about the SIP's main subject, namely the different IE(s) of which digital representations are being delivered, and preservation information about the SIP as a whole (e.g. the software used to create the SIP).
-In addition, a `mets.xml` file supplies information about the SIP's structure (in particular that of the package level) and administrative information about the SIP's submission (e.g. the organization that submits the SIP).
+In addition, a `METS.xml` file supplies information about the SIP's structure (in particular that of the package level) and administrative information about the SIP's submission (e.g. the organization that submits the SIP).
 
 The [_representation level_]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/sip_structure/6_structure_representation.md %}) contains the media files, grouped in representation folders.
-Each representation folder also contains its own `mets.xml` file, together with descriptive and preservation information about a specific representation of the IE(s) of the SIP situated at the _package level_ and preservation information about the media files.
+Each representation folder also contains its own `METS.xml` file, together with descriptive and preservation information about a specific representation of the IE(s) of the SIP situated at the _package level_ and preservation information about the media files.
 
 ## Running example
 

--- a/docs/diginstroom/sip/2.0/usecases/2d-artwork.md
+++ b/docs/diginstroom/sip/2.0/usecases/2d-artwork.md
@@ -82,7 +82,7 @@ It has the following directory structure:
 
 ```plaintext
 root_directory
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -91,7 +91,7 @@ root_directory
 │
 └── representations
     |── representation_1       # overview with frame
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   │   └── 7m03z1634f_overzichtsopname_metlijst_tiff.tiff
     |   └──metadata
@@ -100,7 +100,7 @@ root_directory
     |      └── preservation
     |          └── premis.xml
     |── representation_2       # overview without frame
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   │   └── 7m03z1634f_overzichtsopname_zonderlijst_tiff.tif
     |   └──metadata
@@ -109,14 +109,14 @@ root_directory
     |      └── preservation
     |          └── premis.xml
     |── representation_3       # composed stitch 
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   │   └── 7m03z1634f_stitch_tiff.tif
     |   └──metadata    
     |      └── preservation
     |          └── premis.xml
     |── representation_4       # stitch 
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   |   |── 7m03z1634f_deelopname1_tiff.tif
     |   |   |── 7m03z1634f_deelopname2_tiff.tif
@@ -126,7 +126,7 @@ root_directory
     |       └── preservation
     |           └── premis.xml
     └── representation_5       # target 
-       │── mets.xml
+       │── METS.xml
        |── data
        │   └── 7m03z1634f_target_tiff.tif
        └── metadata

--- a/docs/diginstroom/sip/2.0/usecases/3d-scan.md
+++ b/docs/diginstroom/sip/2.0/usecases/3d-scan.md
@@ -93,7 +93,7 @@ It has the following directory structure:
 
 ```plaintext
 root_directory
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -102,7 +102,7 @@ root_directory
 │
 └── representations
     |── representation_1       # high-poly capture for print
-    |   │── mets.xml
+    |   │── METS.xml
     |   └── data  
     |   │   └── qv3bz95m19_ARCH_STL.STL              
     |   │
@@ -112,7 +112,7 @@ root_directory
     |       └── preservation
     |           └── premis.xml
     |── representation_2       # high-poly capture
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   |   |── qv3bz95m19_ARCH_OBJ.OBJ       # polygon file    
     |   |   |── qv3bz95m19_ARCH_TIFF_COLOR.TIFF      # texture image       
@@ -124,7 +124,7 @@ root_directory
     |       └── preservation
     |           └── premis.xml
     └──representation_3       # low-poly capture
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   |   |── qv3bz95m19_VER_OBJ.OBJ       # polygon file    
     |   |   |── qv3bz95m19_VER_COLOR_BMP.BMP             # texture image       
@@ -136,7 +136,7 @@ root_directory
     |       └──preservation
     |          └── premis.xml
     └── representation_4       # quality assessment reference
-    |    │── mets.xml
+    |    │── METS.xml
     |    |──data
     |    |  |── qv3bz95m19_REF_OBJ.OBJ               # polygon file    
     |    |  |── qv3bz95m19_REF_BMP.BMP               # texture image      
@@ -149,7 +149,7 @@ root_directory
     |       └── preservation
     |           └── premis.xml
     └── representation_5       # additional photography
-        │── mets.xml
+        │── METS.xml
         |── data
         |   |── qv3bz95m19_FOTO1_TIFF.TIFF
         |   |── qv3bz95m19_FOTO2_TIFF.TIFF                   

--- a/docs/diginstroom/sip/2.0/usecases/gigapixel-artwork.md
+++ b/docs/diginstroom/sip/2.0/usecases/gigapixel-artwork.md
@@ -85,7 +85,7 @@ It has the following directory structure:
 
 ```plaintext
 root_directory
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -94,7 +94,7 @@ root_directory
 │
 └── representations
     |── representation_1       # overview with frame
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   │   └── cf9j41p15z_overzichtsopname_metlijst_tiff.tiff
     |   └──metadata
@@ -103,7 +103,7 @@ root_directory
     |      └── preservation
     |          └── premis.xml
     |── representation_2       # overview without frame
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   │   └── cf9j41p15z_overzichtsopname_zonderlijst_tiff.tiff
     |   └──metadata
@@ -112,7 +112,7 @@ root_directory
     |      └── preservation
     |          └── premis.xml
     |── representation_3       # composed stitch 
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   │   └── cf9j41p15z_stitch_bigtiff.tiff
     |   └──metadata
@@ -121,7 +121,7 @@ root_directory
     |      └── preservation
     |          └── premis.xml
     |── representation_4       # composed stitch in PSB
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   │   └── cf9j41p15z_stitch_psb.psb
     |   └──metadata
@@ -130,7 +130,7 @@ root_directory
     |      └── preservation
     |          └── premis.xml
     |── representation_5       # stitch 
-    |   │── mets.xml
+    |   │── METS.xml
     |   |── data
     |   |   |── cf9j41p15z_Kolom1_deelopname1_tiff.tiff
     |   |   |── cf9j41p15z_Kolom1_deelopname2_tiff.tiff
@@ -142,7 +142,7 @@ root_directory
     |       └── preservation
     |           └── premis.xml
     └── representation_6       # target 
-       │── mets.xml
+       │── METS.xml
        |── data
        │   └── cf9j41p15z_target_tiff.tiff
        └── metadata

--- a/docs/diginstroom/sip/2.0/usecases/newspaper-pdf.md
+++ b/docs/diginstroom/sip/2.0/usecases/newspaper-pdf.md
@@ -76,7 +76,7 @@ It has the following directory structure:
 
 ```plaintext
 root_directory
-│──mets.xml
+│──METS.xml
 │──metadata
 |   |──descriptive
 |   |  └──mods.xml
@@ -85,7 +85,7 @@ root_directory
 │
 └──representations
     │──representation_1
-    │    │──mets.xml
+    │    │──METS.xml
     │    │──data
     │    |   |──18950101_0001.tiff
     │    |   |──18950101_0002.tiff
@@ -96,7 +96,7 @@ root_directory
     │            └──premis.xml
     │
     │──representation_2
-    │    │──mets.xml
+    │    │──METS.xml
     │    │──data
     │    |   |──18950101_0001.xml
     │    |   |──18950101_0002.xml
@@ -107,7 +107,7 @@ root_directory
     │          └──premis.xml
     │
     └──representation_3
-         │──mets.xml
+         │──METS.xml
          │──data
          |   └──18950101.pdf
          │

--- a/docs/diginstroom/sip/2.0/usecases/newspaper.md
+++ b/docs/diginstroom/sip/2.0/usecases/newspaper.md
@@ -72,7 +72,7 @@ It has the following directory structure:
 
 ```plaintext
 root_directory
-│──mets.xml
+│──METS.xml
 │──metadata
 |   |──descriptive
 |   |  └──mods.xml
@@ -81,7 +81,7 @@ root_directory
 │
 └──representations
     │──representation_1
-    │    │──mets.xml
+    │    │──METS.xml
     │    │──data
     │    |   |──18950101_0001.tiff
     │    |   |──18950101_0002.tiff
@@ -92,7 +92,7 @@ root_directory
     │            └──premis.xml
     │
     └──representation_2
-         │──mets.xml
+         │──METS.xml
          │──data
          |   |──18950101_0001.xml
          |   |──18950101_0002.xml

--- a/docs/diginstroom/sip/2.0/usecases/single-file.md
+++ b/docs/diginstroom/sip/2.0/usecases/single-file.md
@@ -51,7 +51,7 @@ It has the following directory structure:
 
 ```plaintext
 basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -60,7 +60,7 @@ basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec
 │
 └── representations
     └──representation_1
-       │── mets.xml
+       │── METS.xml
        └──data
        |  └── D523F963.jpg
        │

--- a/docs/diginstroom/sip/2.0/usecases/video-with-subtitles.md
+++ b/docs/diginstroom/sip/2.0/usecases/video-with-subtitles.md
@@ -67,7 +67,7 @@ It has the following directory structure:
 
 ```plaintext
 subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6
-│── mets.xml
+│── METS.xml
 │── metadata
 |   |── descriptive
 |   |   └── dc+schema.xml
@@ -76,7 +76,7 @@ subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6
 │
 └── representations
     └──representation_1
-       │── mets.xml
+       │── METS.xml
        └──data
        |  |── broadcaster_news_20220516.srt
        |  └── broadcaster_news_20220516.mp4


### PR DESCRIPTION
The E-ARK spec specifies that the naming of the METS files is case sensitive. It should be `METS.xml` instead of `mets.xml` for every METS file.