### PR TITLE
SIP-15 Add reqs re. representation mets/structMap/div/div/@LABEL='data'

### DIFF
--- a/docs/diginstroom/sip/2.0/sip_structure/6_structure_representation.md
+++ b/docs/diginstroom/sip/2.0/sip_structure/6_structure_representation.md
@@ -260,7 +260,7 @@ A summary of all possible references and their obligation is given in the table 
 ### \<structMap\> section
 
 The `structMap` element outlines the hierarchical structure of the representation level of the SIP.
-Its requirements are very similar to the package level, however, instead of pointing to the contained representations, a `Representations` division points to the contained files. 
+Its requirements are very similar to the package level, however, instead of pointing to the contained representations, a `data` division points to the contained files. 
 
 ***Example***
 
@@ -269,47 +269,47 @@ Its requirements are very similar to the package level, however, instead of poin
     <div ID="uuid-a5e05d29-49d9-4466-b070-19b8990b5029" LABEL="representation_1">
         <div ID="uuid-af54ed63-8361-4d90-a30f-99d02de24857" LABEL="Metadata" 
             ADMID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482" />
-        <div ID="uuid-c137b167-7254-4085-b965-75980976638d" LABEL="Representations">
+        <div ID="uuid-c137b167-7254-4085-b965-75980976638d" LABEL="data">
             <fptr FILEID="uuid-d020d7d1-f258-40af-8788-04cf62a0032b" />
         </div>
     </div>
 </structMap>
 ```
 
-| Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']` |
+| Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='data']` |
 |-----------------------|-----------|
 | Name | Content division |
-| Description | The data referenced in the file section file groups are described in the structural map within a single sub-division called `Representations`. |
+| Description | The data referenced in the file section file groups are described in the structural map within a single sub-division called `data`. |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 
-| <a id="structMap-csip-div-div-representations-id"></a>Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']/@ID` |
+| <a id="structMap-csip-div-div-representations-id"></a>Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='data']/@ID` |
 |-----------------------|-----------|
 | Name | Content division identifier |
-| Description | A unique identifier to the `Representations` file group. This can be used for internal package references. |
+| Description | A unique identifier to the `data` division. This can be used for internal package references. |
 | Datatype | [ID]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/2_terminology.md %}#id) |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 
-| Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']` |
+| Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='data']` |
 |-----------------------|-----------|
 | Name | Content division label |
-| Description | The representations `div` element’s `@LABEL` attribute value MUST be `Representations`. |
+| Description | The representations `div` element’s `@LABEL` attribute value MUST be `data`. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/2_terminology.md %}#string) |
 | Cardinality | 1..1 |
 | Obligation | MUST |
 
-| Element | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']/fptr` |
+| Element | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='data']/fptr` |
 |-----------------------|-----------|
 | Name | Content division file references |
 | Description | All file groups containing content described in the package are referenced via the relevant file group identifiers.<br>There MUST be one file group reference per `fptr` element. |
 | Cardinality | 1..* |
 | Obligation | MUST |
 
-| <a id="structMap-csip-div-div-data-fptr-fileid"></a>Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']/fptr/@FILEID` |
+| <a id="structMap-csip-div-div-data-fptr-fileid"></a>Attribute | `mets/structMap[@LABEL='CSIP']/div/div[@LABEL='data']/fptr/@FILEID` |
 |-----------------------|-----------|
 | Name | Content division file group references |
-| Description | The pointer to the identifier for the `Representations` file group. |
+| Description | The pointer to the identifier for the `data` file group.<br>This identifier MUST correspond to an identifier of a `file/@ID` attribute in the `fileSec` section of the METS file.|
 | Datatype | [ID]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/2_terminology.md %}#id) |
 | Cardinality | 1..1 |
 | Obligation | MUST |


### PR DESCRIPTION
> CSIP107
> The package’s representation division `<div>` element `@LABEL` attribute value must be the path to the representation level METS document starting with the value “Representations” followed by the main folder name for example “Representations/submission” and “Representations/ingest”.