### PR TITLE
Add prefix `schema` to roleName attribute on Roles

### DIFF
--- a/docs/diginstroom/sip/2.1/profiles/basic.md
+++ b/docs/diginstroom/sip/2.1/profiles/basic.md
@@ -159,7 +159,7 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 | Element | `metadata/dcterms:publisher` |
 |-----------------------|-----------|
 | Name | Publisher |
-| Description | A publisher of the Intellectual Entity. This element is an alias for `metadata/schema:creator` without the attribute `@roleName`. |
+| Description | A publisher of the Intellectual Entity. This element is an alias for `metadata/schema:creator` without the attribute `@schema:roleName`. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#string) |
 | Cardinality | 0..* |
 | Obligation | MAY |
@@ -167,7 +167,7 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 | Element | `metadata/dcterms:contributor` |
 |-----------------------|-----------|
 | Name | Contributor |
-| Description | A contributor to the Intellectual Entity. This element is an alias for `metadata/schema:creator` without the attribute `@roleName`. |
+| Description | A contributor to the Intellectual Entity. This element is an alias for `metadata/schema:creator` without the attribute `@schema:roleName`. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#string) |
 | Cardinality | 0..* |
 | Obligation | MAY |
@@ -175,7 +175,7 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 | Element | `metadata/dcterms:creator` |
 |-----------------------|-----------|
 | Name | Creator |
-| Description | An author or creator of the Intellectual Entity. This element is an alias for `metadata/schema:creator` without the attribute `@roleName`. |
+| Description | An author or creator of the Intellectual Entity. This element is an alias for `metadata/schema:creator` without the attribute `@schema:roleName`. |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#string) |
 | Cardinality | 0..* |
 | Obligation | MAY |
@@ -267,7 +267,7 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 | Cardinality | 0..* |
 | Obligation | MAY |
 
-| Attribute | `metadata/(schema:creator|schema:publisher|schema:contributor)/@roleName` |
+| Attribute | `metadata/(schema:creator|schema:publisher|schema:contributor)/@schema:roleName` |
 |-----------------------|-----------|
 | Name | Role creator, publisher, or contributor |
 | Description | The role with which the creator, publisher, or contributor was involved in creating, publishing or contributing to the digitally reproduced artwork.  |


### PR DESCRIPTION
There is a minor inconsistency:
- The spec uses `@roleName`
- The film SIP sample uses `@schema:roleName` ([link](https://github.com/viaacode/documentation/blob/09bc32e3650fa6c926c85f201881fb9610390981/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/descriptive/dc%2Bschema.xml#L29))

I updated the spec to use the full `@schema:roleName`.