### PR TITLE
Change dcterms:type to dcterms:format

### DIFF
--- a/docs/diginstroom/sip/2.1/profiles/basic.md
+++ b/docs/diginstroom/sip/2.1/profiles/basic.md
@@ -236,13 +236,14 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 | Cardinality | 0..1 |
 | Obligation | SHOULD |
 
-| Element | `metadata/dcterms:type` |
+| Element | `metadata/dcterms:format` |
 |-----------------------|-----------|
-| Name | Type |
+| Name | Format |
 | Description | The classification of this Intellectual Entity . |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#string) |
-| Cardinality | 0..* |
-| Obligation | MAY |
+| Vocabulary | `audio`, `video`, `film`, `paper`, `newspaper`, `newspaperpage`, `videofragment`, `audiofragment`  |
+| Cardinality | 1..1 |
+| Obligation | MUST |
 
 #### Schema.org elements
 


### PR DESCRIPTION
1. I changed `dcterms:type` to `dcterms:format` in the SIP spec. This because:
    - `dct:format` is used in the film SIP sample ([link](https://github.com/viaacode/documentation/blob/162608bfc2dffd3b5ab6a0738f22d2de248e502e/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/descriptive/dc%2Bschema.xml#L37)) but is not mentioned anywhere in the SIP spec.
    - In the mapping for the registration tool, Milan mapped `type` to `dct:format` ([link](https://docs.google.com/spreadsheets/d/1We3yCI_IC12dsDQLKz3sZoNKRciQqeIuugf2yRhLqcc/edit?usp=sharing))

2. Furthermore, I changed the cardinality from `0..1` to `1..1`. This because `dct:format` is mandatory in the KG and there is no other way i know of deducing the format from the SIP.