### PR TITLE
Replace significant properties key/value pairs

### DIFF
--- a/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/descriptive/dc+schema.xml
+++ b/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/descriptive/dc+schema.xml
@@ -34,6 +34,7 @@
   <dcterms:rightsHolder>© dummyorganisatie</dcterms:rightsHolder>
 
   <!-- IE type -->
+  <dcterms:type>silent film</dcterms:type>
   <dcterms:format>film</dcterms:format>
 
   <!-- VIAA licenses for the resource -->

--- a/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/preservation/premis.xml
+++ b/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/preservation/premis.xml
@@ -112,30 +112,29 @@
     </premis:objectIdentifier>
 
     <premis:significantProperties>
-      <premis:significantPropertiesExtension xmlns:schema='https://schema.org'
-        xmlns:haObj='https://data.hetarchief.be/ns/object/' xmlns:haDes='https://data.hetarchief.be/ns/description/'>
+      <premis:significantPropertiesExtension>
 
-        <haObj:CarrierRepresentation>
-          <haDes:numberOfReels>1</haDes:numberOfReels>
-          <schema:inLanguage>Silent Movie</schema:inLanguage>
-        </haObj:CarrierRepresentation>
+        <CarrierRepresentation>
+          <numberOfReels>1</numberOfReels>
+          <inLanguage>Silent Movie</inLanguage>
+        </CarrierRepresentation>
 
-        <haDes:ImageReel>
-          <schema:identifier>AFLM_FEL_001392</schema:identifier>
+        <ImageReel>
+          <identifier>AFLM_FEL_001392</identifier>
           
-          <haDes:coloringType>B/W and Color</haDes:coloringType> 
-          <schema:material>acetate</schema:material>
-          <haObj:preservationProblem>Base Scratching remarks: Light scratches, lines and stripes. Some cables.\nvinegar date: 2021-06-30 pH value:PH 4.8</haObj:preservationProblem>
+          <coloringType>B/W and Color</coloringType> 
+          <material>acetate</material>
+          <preservationProblem>Base Scratching remarks: Light scratches, lines and stripes. Some cables.\nvinegar date: 2021-06-30 pH value:PH 4.8</preservationProblem>
 
-          <premis:storageMedium>
-            <premis:medium>8mmfilm</premis:medium>
-          </premis:storageMedium>
+          <storageMedium>
+            <medium>8mmfilm</medium>
+          </storageMedium>
 
-          <haDes:aspectRatio>1:37</haDes:aspectRatio>
+          <aspectRatio>1:37</aspectRatio>
 
           <!-- TODO: look for a suitable mapping for material type -->
-          <!-- <material_type>Original positive</material_type> -->
-        </haDes:ImageReel>
+          <materialType>Original positive</materialType>
+        </ImageReel>
       </premis:significantPropertiesExtension>
     </premis:significantProperties>
 

--- a/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/preservation/premis.xml
+++ b/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/preservation/premis.xml
@@ -110,67 +110,34 @@
       <premis:objectIdentifierType>Batch-ID</premis:objectIdentifierType>
       <premis:objectIdentifierValue>FLMB20</premis:objectIdentifierValue>
     </premis:objectIdentifier>
-    <premis:objectIdentifier>
-      <premis:objectIdentifierType>Barcode-image-reels</premis:objectIdentifierType>
-      <premis:objectIdentifierValue>AFLM_FEL_001392</premis:objectIdentifierValue>
-    </premis:objectIdentifier>
 
     <premis:significantProperties>
-      <premis:significantPropertiesType>Projection-speed</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>18 f/s</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>CP-evaluation</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>4 interesting, HR digitisation</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Image-or-sound</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>image</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Aspect-ratio</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>1:37</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Number-of-reels</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>1</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Preservation-problems</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>Base Scratching remarks: Light scratches, lines and
-        stripes. Some cables.\nvinegar date: 2021-06-30 pH value:PH 4.8</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Film-base</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>acetate</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Subtitles-present</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>no</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Silent-or-spoken-movie</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>Silent Movie</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Color-or-Black-and-white</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>B/W and Color</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesExtension xmlns:schema='https://schema.org'>
-        <schema:duration>0:04:55</schema:duration>
-        <schema:material>Original positive</schema:material>
-        <schema:size>
-          <schema:unitCode>MTR</schema:unitCode>
-          <schema:QuantitativeValue>135</schema:QuantitativeValue>
-        </schema:size>
+      <premis:significantPropertiesExtension xmlns:schema='https://schema.org'
+        xmlns:haObj='https://data.hetarchief.be/ns/object/' xmlns:haDes='https://data.hetarchief.be/ns/description/'>
+
+        <haObj:CarrierRepresentation>
+          <haDes:numberOfReels>1</haDes:numberOfReels>
+          <schema:inLanguage>Silent Movie</schema:inLanguage>
+        </haObj:CarrierRepresentation>
+
+        <haDes:ImageReel>
+          <schema:identifier>AFLM_FEL_001392</schema:identifier>
+          
+          <haDes:coloringType>B/W and Color</haDes:coloringType> 
+          <schema:material>acetate</schema:material>
+          <haObj:preservationProblem>Base Scratching remarks: Light scratches, lines and stripes. Some cables.\nvinegar date: 2021-06-30 pH value:PH 4.8</haObj:preservationProblem>
+
+          <premis:storageMedium>
+            <premis:medium>8mmfilm</premis:medium>
+          </premis:storageMedium>
+
+          <haDes:aspectRatio>1:37</haDes:aspectRatio>
+
+          <!-- TODO: look for a suitable mapping for material type -->
+          <!-- <material_type>Original positive</material_type> -->
+        </haDes:ImageReel>
       </premis:significantPropertiesExtension>
-
     </premis:significantProperties>
-
-    <premis:storage>
-      <premis:storageMedium>8mmfilm</premis:storageMedium>
-    </premis:storage>
 
     <!-- relationship between representation and its IE -->
     <premis:relationship>


### PR DESCRIPTION
This is a first attempt at replacing the `significantProperties` key/value pairs with a well defined specification. Before doing the changes to the spec itself, I first want to do them to the film SIP sample as it's easier to iterate on and is needed for the parsing for SIP which is currently in progress.

The idea is to place a `haObj:CarrierRepresentation`, `haDes:ImageReel`or `haDes:AudioReel` inside the `premis:significantPropertiesExtension`. That way the properties for those elements are cleanly separated. The image reel and audio reel elements can be repeated if required.

(Take a break here from this comment and have a look at the changes)

Most properties can easily be translated into existing properties from the datamodels. One property that is not as trivial is "image/sound" which can have four values. I propose to translate it as follows: E.g. "image without sound" is mapped into 

inside `dc+schema.xml`
```xml
<dcterms:type>sound film</dcterms:type>
```

inside `premis.xml`:
```xml
<premis:significantPropertiesExtension>
	<haDes:CarrierRepresentation>
		<haDes:hasMissingAudioReels>true</haDes:hasMissingAudioReels>
	</haDes:CarrierRepresentation>
</premis:significantPropertiesExtension>
```

This table shows how to map each of the possible values:

| registratietool     | SIP                              |
| ------------------- | -------------------------------- |
| image               | silent film                      |
| image without sound | hasMissingAudioReels, sound film |
| sound without image | hasMissingImageReels, sound film |
| image with sound    | sound film                       |

> [!IMPORTANT]
> Important to note is that this requires a small change from the registration tool because this mapping requires changing `dc+schema.xml`.

## TODO

The following items are open:
- [ ] add `haDes:aspectRatio` to image and audio reels in the datamodels
- [ ] add `schema:inLanguage` to carrier representation in the datamodels
- [ ] Find a suitable place for "materiaal type" in the SIP
- [ ] Decide where to put the IE class (currently under `dcterms:type`)
- [ ] Document the changes is the SIP spec. (Perhaps in a different PR)
- [ ] Validate the changed document with the PREMIS xsd