### PR TITLE
Add format to SIP basic descriptive spec

### DIFF
--- a/docs/diginstroom/sip/2.1/profiles/basic.md
+++ b/docs/diginstroom/sip/2.1/profiles/basic.md
@@ -241,8 +241,18 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 | Name | Type |
 | Description | The classification of this Intellectual Entity . |
 | Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#string) |
-| Cardinality | 0..* |
-| Obligation | MAY |
+| Vocabulary | `Audio`, `DVD`, `DVD chapter`, `Film`, `Image`, `Newspaper edition`, `Newspaper issue page`, `Video`, `Silent film`, `Sound film` |
+| Cardinality | 1..1 |
+| Obligation | MUST |
+
+| Element | `metadata/dcterms:format` |
+|-----------------------|-----------|
+| Name | Format |
+| Description | The format of this Intellectual Entity . |
+| Datatype | [String]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#string) |
+| Vocabulary | `audio`, `video`, `film`, `paper`, `newspaper`, `newspaperpage`, `videofragment`, `audiofragment`  |
+| Cardinality | 1..1 |
+| Obligation | MUST |
 
 #### Schema.org elements
 


### PR DESCRIPTION
I've added `dct:format` to the basic description spec. It is used in the film asset: [link](https://github.com/viaacode/documentation/blob/8f709b7d8494b4737c3323d33964b4f4c6e537cd/assets/sip_samples/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/descriptive/dc%2Bschema.xml#L37)

I've made both `dct:format` and `dct:type` obligatory and used the vocabulary from the datamodels.