### PR TITLE
2.1 - Make temporal and credit text langstrings

### DIFF
--- a/docs/diginstroom/sip/2.1/profiles/basic.md
+++ b/docs/diginstroom/sip/2.1/profiles/basic.md
@@ -188,7 +188,7 @@ For elements that require the `@xml:lang` attribute, it is still necessary to su
 | Cardinality | 0..* |
 | Obligation | MAY |
 
-| Element | `metadata/dcterms:temporal` |
+| Element | `metadata/dcterms:temporal[@xml:lang=*]` |
 |-----------------------|-----------|
 | Name | Temporal |
 | Description | Temporal coverage information on the Intellectual Entity |

--- a/docs/diginstroom/sip/2.1/profiles/film.md
+++ b/docs/diginstroom/sip/2.1/profiles/film.md
@@ -111,7 +111,7 @@ root_directory
 | Cardinality | 0..1 |
 | Obligation | MAY |
 
-| Element | `metadata/schema:creditText` |
+| Element | `metadata/schema:creditText[@xml:lang=*]` |
 |-----------------------|-----------|
 | Name | Credit text |
 | Description | Text that can be used to credit person(s) and/or organization(s) associated with a film. |


### PR DESCRIPTION
Add lang tags to temporal and credit text. Just as they are in the datamodels. Even tough I should stop making tweaks to the spec at some point I'm hoping this small change can still be included in the next release :)